### PR TITLE
refactor: build stand-alone docker image from Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .git
 node_modules
 npm-debug
+packages/api-server/lib
+packages/godwoken/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
-FROM nervos/godwoken-prebuilds:v0.2.0-rc2
 
-WORKDIR "/godwoken-web3"
+FROM node:14-bullseye
+
+COPY . /godwoken-web3/.
+RUN cd /godwoken-web3 && yarn && yarn build
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \
+ && apt-get install curl -y \
  && apt-get install jq -y \
  && apt-get clean \
  && echo "Finished installing dependencies"
 
-COPY package*.json ./
-COPY packages/godwoken/package*.json ./packages/godwoken/
-COPY packages/api-server/package*.json ./packages/api-server/
-RUN yarn install
-
-COPY --chown=node . ./
-EXPOSE 8024
-
-USER node
-CMD ["node", "version"]
+EXPOSE 8024 3000

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+SHELL := /bin/bash
+
+IMAGE_NAME := nervos/godwoken-web3-prebuilds
+
+build-push:
+	@read -p "Please Enter New Image Tag: " VERSION ; \
+	docker build . -t ${IMAGE_NAME}:$$VERSION ; \
+	docker push ${IMAGE_NAME}:$$VERSION
+
+build-test-image:
+	docker build . -t ${IMAGE_NAME}:latest-test
+
+test:
+	make build-test-image
+	make test-jq
+	make test-web3
+
+test-jq:
+	docker run --rm ${IMAGE_NAME}:latest-test /bin/bash -c "jq -V"
+
+test-web3:
+	docker run --rm -v `pwd`:/app ${IMAGE_NAME}:latest-test /bin/bash -c "cp -r godwoken-web3/node_modules app/node_modules"
+	yarn check --verify-tree
+	

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ Eth wallet mode: http://your-url/eth-wallet (for wallet like metamask, please co
 
 WebSocket url: ws://your-url/ws
 
+### Docker Prebuilds
+
+local development:
+
+```sh
+make build-test-image # (tag: latest-test)
+```
+
+push to docker:
+
+```sh
+make build-push # needs login, will ask you for tag
+```
+
+resource:
+
+- docker image: https://hub.docker.com/repository/docker/nervos/godwoken-web3-prebuilds
+- code is located in `/godwoken-web3` with node_modules already installed and typescript compiled to js code.
+
 ## Web3 RPC Modules
 
 ### net


### PR DESCRIPTION
we split the two js projects docker image into stand-alone one.

ref: 

- https://github.com/RetricSu/godwoken-polyman/commit/a06e9bea6a08ff5770c9fbb98dfbcdf6fe528de0
- https://github.com/RetricSu/godwoken-docker-js-prebuilds