### PR TITLE
fix(v0.12.x): allow address array when query logs

### DIFF
--- a/packages/api-server/src/db/index.ts
+++ b/packages/api-server/src/db/index.ts
@@ -438,7 +438,7 @@ function formatErrorTransactionReceipt(
   };
 }
 
-function normalizeQueryAddress(address: HexString | undefined) {
+function normalizeQueryAddress(address: HexString) {
   if (address && typeof address === "string") {
     return address.toLowerCase();
   }
@@ -449,6 +449,10 @@ function normalizeQueryAddress(address: HexString | undefined) {
 function normalizeLogQueryAddress(
   address: HexString | HexString[] | undefined
 ) {
+  if (!address) {
+    return address;
+  }
+
   if (address && Array.isArray(address)) {
     return address.map((a) => normalizeQueryAddress(a));
   }

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -226,9 +226,18 @@ export const validators = {
 
     // validate `address`
     if (address !== undefined && address !== null) {
-      const addressErr = verifyAddress(address, index);
-      if (addressErr !== undefined) {
-        return addressErr;
+      if (Array.isArray(address)) {
+        for (const addr of address) {
+          const addressErr = verifyAddress(addr, index);
+          if (addressErr !== undefined) {
+            return addressErr;
+          }
+        }
+      } else {
+        const addressErr = verifyAddress(address, index);
+        if (addressErr !== undefined) {
+          return addressErr;
+        }
       }
     }
 


### PR DESCRIPTION
```sh
{
    "jsonrpc": "2.0",
    "method": "eth_getLogs",
    "params": [
        {
            "fromBlock": "0x329FA",
            "toBlock": "0x329FA",
            "address": ["0xb66d669ea71D35e863cc2bcb7243d657c59c855f", "0x1640cf89d56d4ca90844b46851080084e8fd7745"]
        }
    ],
    "id": 1
}  
```
---

```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        {
            "address": "0x1640cf89d56d4ca90844b46851080084e8fd7745",
            "blockHash": "0x93663e881060b39230230f58f2d790a7e08f578c0cbc3e328fbd733dbea0b0a7",
            "blockNumber": "0x329fa",
            "transactionIndex": "0x137",
            "transactionHash": "0x1424c12954c2df97ab5ee99103f0056cc0ca3dcf751077407f5b2e4ae468762d",
            "data": "0x00000000000000000000000000000000000000000000002994436442849c0000",
            "logIndex": "0x0",
            "topics": [
                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
                "0x0000000000000000000000000000000000000000000000000000000000000000",
                "0x0000000000000000000000008bf6c7014c32887b38c739b8f8eed124e4ff25a5"
            ],
            "removed": false
        },
        {
            "address": "0xb66d669ea71d35e863cc2bcb7243d657c59c855f",
            "blockHash": "0x93663e881060b39230230f58f2d790a7e08f578c0cbc3e328fbd733dbea0b0a7",
            "blockNumber": "0x329fa",
            "transactionIndex": "0x135",
            "transactionHash": "0xa4516d181eee05a717c2f99f3cbad7aac61faa88741d5182f9f9e9111b2f56d5",
            "data": "0x0000000000000000000000000000000000000000000001913581efd24a0400000000000000000000000000000000000000000000000001913581efd24a040000",
            "logIndex": "0x6",
            "topics": [
                "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f",
                "0x000000000000000000000000b7991b41830d277ace908df3dc94e3d98450e073"
            ],
            "removed": false
        },
```