### PR TITLE
fix(main): use full node for gw_get_last_submitted_info

### DIFF
--- a/packages/api-server/src/methods/modules/gw.ts
+++ b/packages/api-server/src/methods/modules/gw.ts
@@ -405,7 +405,7 @@ export class Gw {
 
   async get_last_submitted_info(args: any[]) {
     try {
-      const result = await this.readonlyRpc.gw_get_last_submitted_info(...args);
+      const result = await this.rpc.gw_get_last_submitted_info(...args);
       return result;
     } catch (error) {
       parseGwRpcError(error);


### PR DESCRIPTION
## before
```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32601,
        "message": "Method not found"
    }
}
```
----
## after
```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "transaction_hash": "0x26a80599cd6093002161b126dc1176182480adc27b7ff93bf6a796fdfddf8795"
    }
}
```