### PR TITLE
fix: Error info for invalid exit code 92

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "gw-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?tag=v0.6.9-rc1#2a42b89401cae2ea7f12ee2bc51401ac8616549d"
+source = "git+https://github.com/classicalliu/godwoken.git?branch=add-exit-code-to-error-receipt#4ef2688ed950b5dd4ac6f86e5b9c1453429d0700"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "gw-hash"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?tag=v0.6.9-rc1#2a42b89401cae2ea7f12ee2bc51401ac8616549d"
+source = "git+https://github.com/classicalliu/godwoken.git?branch=add-exit-code-to-error-receipt#4ef2688ed950b5dd4ac6f86e5b9c1453429d0700"
 dependencies = [
  "blake2b-ref",
 ]
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "gw-jsonrpc-types"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?tag=v0.6.9-rc1#2a42b89401cae2ea7f12ee2bc51401ac8616549d"
+source = "git+https://github.com/classicalliu/godwoken.git?branch=add-exit-code-to-error-receipt#4ef2688ed950b5dd4ac6f86e5b9c1453429d0700"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "gw-types"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?tag=v0.6.9-rc1#2a42b89401cae2ea7f12ee2bc51401ac8616549d"
+source = "git+https://github.com/classicalliu/godwoken.git?branch=add-exit-code-to-error-receipt#4ef2688ed950b5dd4ac6f86e5b9c1453429d0700"
 dependencies = [
  "cfg-if 0.1.10",
  "ckb-fixed-hash",

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gw-types = { git = "https://github.com/nervosnetwork/godwoken.git", tag = "v0.6.9-rc1" }
-gw-common = { git = "https://github.com/nervosnetwork/godwoken.git", tag = "v0.6.9-rc1" }
-gw-jsonrpc-types = { git = "https://github.com/nervosnetwork/godwoken.git", tag = "v0.6.9-rc1" }
+gw-types = { git = "https://github.com/classicalliu/godwoken.git", branch = "add-exit-code-to-error-receipt" }
+gw-common = { git = "https://github.com/classicalliu/godwoken.git", branch = "add-exit-code-to-error-receipt" }
+gw-jsonrpc-types = { git = "https://github.com/classicalliu/godwoken.git", branch = "add-exit-code-to-error-receipt" }
 ckb-hash = "0.100.0"
 ckb-types = "0.100.0"
 anyhow = "1.0"

--- a/crates/indexer/src/ws_client.rs
+++ b/crates/indexer/src/ws_client.rs
@@ -102,6 +102,7 @@ fn to_result<T: DeserializeOwned>(output: Output) -> anyhow::Result<T> {
 fn convert_error_tx_receipt(
     receipt: gw_jsonrpc_types::godwoken::ErrorTxReceipt,
 ) -> gw_types::offchain::ErrorTxReceipt {
+    let exit_code: u32 = receipt.exit_code.into();
     gw_types::offchain::ErrorTxReceipt {
         tx_hash: {
             let mut buf = [0u8; 32];
@@ -111,5 +112,6 @@ fn convert_error_tx_receipt(
         block_number: receipt.block_number.into(),
         return_data: receipt.return_data.as_bytes().to_vec(),
         last_log: receipt.last_log.map(Into::into),
+        exit_code: exit_code as u8 as i8,
     }
 }

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -12,9 +12,9 @@ serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 ckb-jsonrpc-types = "0.100.0"
 ckb-types = "0.100.0"
-gw-jsonrpc-types = { git = "https://github.com/nervosnetwork/godwoken.git", tag = "v0.6.9-rc1" }
-gw-types = { git = "https://github.com/nervosnetwork/godwoken.git", tag = "v0.6.9-rc1" }
-gw-common = { git = "https://github.com/nervosnetwork/godwoken.git", tag = "v0.6.9-rc1" }
+gw-jsonrpc-types = { git = "https://github.com/classicalliu/godwoken.git", branch = "add-exit-code-to-error-receipt" }
+gw-types = { git = "https://github.com/classicalliu/godwoken.git", branch = "add-exit-code-to-error-receipt" }
+gw-common = { git = "https://github.com/classicalliu/godwoken.git", branch = "add-exit-code-to-error-receipt" }
 jsonrpc-core = "17"
 rand = "0.8"
 anyhow = "1.0"

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -41,8 +41,8 @@ export interface GwErrorItem {
 }
 const gwErrorMapping: { [key: string]: { type: string; message: string } } = {
   "92": {
-    type: "GW_SUDT_ERROR_INSUFFICIENT_BALANCE",
-    message: "insufficient balance", // TODO: update message
+    type: "SUDT_ERROR_INSUFFICIENT_BALANCE",
+    message: "sender doesn't have enough funds to send tx",
   },
 };
 

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -2,6 +2,7 @@
 
 import abiCoder, { AbiCoder } from "web3-eth-abi";
 import { FailedReason } from "../base/types/api";
+import { ErrorTransactionReceipt } from "../db/types";
 import { RpcError } from "./error";
 import { GW_RPC_REQUEST_ERROR } from "./error-code";
 import { LogItem, PolyjuiceSystemLog } from "./types";
@@ -200,4 +201,28 @@ export function parsePolyjuiceSystemLog(logItem: LogItem): PolyjuiceSystemLog {
     createdAddress: createdAddress,
     statusCode: statusCode,
   };
+}
+
+export function failedReasonByErrorReceipt(
+  errorReceipt: ErrorTransactionReceipt
+): FailedReason {
+  const statusCode: number = errorReceipt.status_code;
+  const gwErrorItem = gwErrorMapping[statusCode.toString()];
+  if (gwErrorItem != null) {
+    const failedReason: FailedReason = {
+      status_code: "0x" + statusCode.toString(16),
+      status_type: gwErrorItem.type,
+      message: gwErrorItem.message,
+    };
+    return failedReason;
+  }
+
+  // if not in gwErrorMapping
+  const failedReason: FailedReason = {
+    status_code: "0x" + statusCode.toString(16),
+    status_type: evmcCodeTypeMapping[errorReceipt.status_code.toString()],
+    message: errorReceipt.status_reason,
+  };
+
+  return failedReason;
 }

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -58,7 +58,7 @@ import { filterWeb3Transaction } from "../../filter-web3-tx";
 import { Abi, ShortAddress, ShortAddressType } from "@polyjuice-provider/base";
 import { SUDT_ERC20_PROXY_ABI, allowedAddresses } from "../../erc20";
 import { FilterManager } from "../../cache";
-import { parseGwError } from "../gw-error";
+import { failedReasonByErrorReceipt, parseGwError } from "../gw-error";
 import { evmcCodeTypeMapping } from "../gw-error";
 import { Store } from "../../cache/store";
 import { CACHE_EXPIRED_TIME_MILSECS } from "../../cache/constant";
@@ -821,11 +821,8 @@ export class Eth {
         errorReceipt,
         blockHash
       );
-      const failedReason: FailedReason = {
-        status_code: "0x" + errorReceipt.status_code.toString(16),
-        status_type: evmcCodeTypeMapping[errorReceipt.status_code.toString()],
-        message: errorReceipt.status_reason,
-      };
+      const failedReason: FailedReason =
+        failedReasonByErrorReceipt(errorReceipt);
       receipt.failed_reason = failedReason;
       return receipt;
     }


### PR DESCRIPTION
RPC returns by execute tx:

```json
{
  "code": -32600,
  "message": "sudt_error_insufficient_balance: sender doesn't have enough funds to send tx",
  "data": {
    "failed_reason": {
      "status_code": "0x5c",
      "status_type": "SUDT_ERROR_INSUFFICIENT_BALANCE",
      "message": "sender doesn't have enough funds to send tx"
    }
  }
}
```

And example error receipt:

```json
{
    "jsonrpc": "2.0",
    "id": 2,
    "result": {
        "transactionHash": "0x143cf50c044ef1bf258f972d4fd4315f1592b4b4fab1c92a1035936e81a75659",
        "blockHash": "0x25b7727209048f7ed890adee777a3938759350c62db0ad729f824930a5ceb21d",
        "blockNumber": "0x537",
        "transactionIndex": "0x0",
        "gasUsed": "0x4e8c",
        "cumulativeGasUsed": "0x4e8c",
        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
        "logs": [],
        "contractAddress": null,
        "status": "0x0",
        "from": "0x0000000000000000000000000000000000000000",
        "to": null,
        "failed_reason": {
            "status_code": "0x5c",
            "status_type": "SUDT_ERROR_INSUFFICIENT_BALANCE",
            "message": "sender doesn't have enough funds to send tx"
        }
    }
}
```