### PR TITLE
fix(indexer): support compatible_chain_id for calculating eth_tx_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GODWOKEN_READONLY_JSON_RPC=<optional, default equals to GODWOKEN_JSON_RPC>
 ETH_ACCOUNT_LOCK_HASH=<eth account lock script hash>
 ROLLUP_TYPE_HASH=<godwoken rollup type hash>
 ROLLUP_CONFIG_HASH=<godwoken rollup config hash>
-CHAIN_ID=<your chain id in integer>
+COMPATIBLE_CHAIN_ID=<godwoken compatible chain id in integer>
 CREATOR_ACCOUNT_ID=<your creator account id in integer>
 DEFAULT_FROM_ADDRESS=<default from eth address>
 DEFAULT_FROM_ID=<default from eth address's godwoken account id>
@@ -89,6 +89,7 @@ tron_account_lock_hash=<tron account lock script hash, optional>
 godwoken_rpc_url=<godwoken rpc>
 ws_rpc_url=<godwoken websocket rpc>
 pg_url="postgres://username:password@localhost:5432/your_db"
+compatible_chain_id=<godwoken compatible_chain_id in integer>
 EOF
 ```
 

--- a/crates/indexer/src/config.rs
+++ b/crates/indexer/src/config.rs
@@ -14,6 +14,7 @@ pub struct IndexerConfig {
     pub godwoken_rpc_url: String,
     pub ws_rpc_url: String,
     pub pg_url: String,
+    pub compatible_chain_id: u64,
     pub sentry_dsn: Option<String>,
     pub sentry_environment: Option<String>,
 }
@@ -45,6 +46,7 @@ impl Display for IndexerConfig {
         write!(f, "godwoken_rpc_url: {}, ", self.godwoken_rpc_url)?;
         write!(f, "ws_rpc_url: {}, ", self.ws_rpc_url)?;
         write!(f, "pg_url: {}", self.pg_url)?;
+        write!(f, "compatible_chain_id: {}", self.compatible_chain_id)?;
         if let Some(t) = &self.sentry_dsn {
             write!(f, "sentry_dsn: {}, ", t)?;
         } else {

--- a/crates/indexer/src/indexer.rs
+++ b/crates/indexer/src/indexer.rs
@@ -32,6 +32,7 @@ pub struct Web3Indexer {
     rollup_type_hash: H256,
     allowed_eoa_hashes: HashSet<H256>,
     godwoken_rpc_client: GodwokenRpcClient,
+    compatible_chain_id: u64,
 }
 
 impl Web3Indexer {
@@ -42,6 +43,7 @@ impl Web3Indexer {
         eth_account_lock_hash: H256,
         tron_account_lock_hash: Option<H256>,
         gw_rpc_url: &str,
+        compatible_chain_id: u64,
     ) -> Self {
         let mut allowed_eoa_hashes = HashSet::default();
         allowed_eoa_hashes.insert(eth_account_lock_hash);
@@ -56,6 +58,7 @@ impl Web3Indexer {
             rollup_type_hash,
             allowed_eoa_hashes,
             godwoken_rpc_client,
+            compatible_chain_id,
         }
     }
 
@@ -260,7 +263,7 @@ impl Web3Indexer {
                     (Some(address), polyjuice_chain_id)
                 };
                 // calculate chain_id
-                let chain_id: u64 = polyjuice_chain_id as u64;
+                let chain_id: u64 = (self.compatible_chain_id << 32) | (polyjuice_chain_id as u64);
                 let nonce: u32 = l2_transaction.raw().nonce().unpack();
                 let input = polyjuice_args.input.clone().unwrap_or_default();
 

--- a/crates/indexer/src/runner.rs
+++ b/crates/indexer/src/runner.rs
@@ -22,6 +22,7 @@ impl Runner {
             config.eth_account_lock_hash,
             config.tron_account_lock_hash,
             config.godwoken_rpc_url.as_str(),
+            config.compatible_chain_id,
         );
         let godwoken_rpc_client = GodwokenRpcClient::new(config.godwoken_rpc_url.as_str());
         let runner = Runner {

--- a/packages/api-server/src/base/env-config.ts
+++ b/packages/api-server/src/base/env-config.ts
@@ -47,12 +47,12 @@ function getOptional(name: string): string | undefined {
 }
 
 export function calculateChainId(
-  creator_id: number,
-  compatible_chain_id: number
+  creatorId: number,
+  compatibleChainId: number
 ): string {
-  const chain_id_num = compatible_chain_id * Math.pow(2, 32) + creator_id;
+  const chainId = (BigInt(compatibleChainId) << 32n) + BigInt(creatorId);
   console.log(
-    `web3 chain_id: ${chain_id_num}, calculating from compatible_chain_id: ${compatible_chain_id}, creator_id: ${creator_id}`
+    `web3 chain_id: ${chainId}, calculating from compatible_chain_id: ${compatibleChainId}, creator_id: ${creatorId}`
   );
-  return BigInt(chain_id_num).toString(10);
+  return chainId.toString(10);
 }

--- a/packages/api-server/src/base/env-config.ts
+++ b/packages/api-server/src/base/env-config.ts
@@ -9,7 +9,11 @@ export const envConfig = {
   rollupTypeHash: getRequired("ROLLUP_TYPE_HASH"),
   godwokenJsonRpc: getRequired("GODWOKEN_JSON_RPC"),
   creatorAccountId: getRequired("CREATOR_ACCOUNT_ID"),
-  chainId: getRequired("CHAIN_ID"),
+  compatibleChainId: getRequired("COMPATIBLE_CHAIN_ID"),
+  chainId: calculateChainId(
+    +getRequired("CREATOR_ACCOUNT_ID"),
+    +getRequired("COMPATIBLE_CHAIN_ID")
+  ),
   defaultFromAddress: getRequired("DEFAULT_FROM_ADDRESS"),
   defaultFromId: getRequired("DEFAULT_FROM_ID"),
   l2SudtValidatorScriptTypeHash: getRequired(
@@ -40,4 +44,15 @@ function getRequired(name: string): string {
 
 function getOptional(name: string): string | undefined {
   return env[name];
+}
+
+export function calculateChainId(
+  creator_id: number,
+  compatible_chain_id: number
+): string {
+  const chain_id_num = compatible_chain_id * Math.pow(2, 32) + creator_id;
+  console.log(
+    `web3 chain_id: ${chain_id_num}, calculating from compatible_chain_id: ${compatible_chain_id}, creator_id: ${creator_id}`
+  );
+  return BigInt(chain_id_num).toString(10);
 }

--- a/packages/api-server/src/methods/modules/poly.ts
+++ b/packages/api-server/src/methods/modules/poly.ts
@@ -10,7 +10,7 @@ export class Poly {
     try {
       const creatorIdHex = toHexNumber(BigInt(envConfig.creatorAccountId));
       return creatorIdHex;
-    } catch (err) {
+    } catch (err: any) {
       throw new Web3Error(err.message);
     }
   }
@@ -59,7 +59,7 @@ export class Poly {
         chainId: envConfig.chainId || null,
       };
       return chainInfo;
-    } catch (error) {
+    } catch (error: any) {
       throw new Web3Error(error.message);
     }
   }

--- a/scripts/generate-indexer-config.js
+++ b/scripts/generate-indexer-config.js
@@ -16,6 +16,7 @@ let config = {
   tron_account_lock_hash: process.env.TRON_ACCOUNT_LOCK_HASH,
   godwoken_rpc_url: process.env.GODWOKEN_JSON_RPC,
   pg_url: process.env.DATABASE_URL,
+  compatible_chain_id: process.env.COMPATIBLE_CHAIN_ID,
   sentry_dsn: process.env.SENTRY_DNS,
   sentry_environment: process.env.SENTRY_ENVIRONMENT,
 }
@@ -28,8 +29,12 @@ let tomlStr = "";
 
 for (const [key, value] of Object.entries(config)) {
   console.log(`[${key}]: ${value}`)
+  if(value != null && key === "compatible_chain_id"){
+    tomlStr += `${key}=${Number(value)}\n`;
+    continue;
+  }
   if (value != null) {
-    tomlStr += `${key}="${value}"\n`
+    tomlStr += `${key}="${value}"\n`;
   }
 }
 


### PR DESCRIPTION
- https://github.com/nervosnetwork/godwoken-web3/issues/198

in this pr:

- [x] fix the web3-indexer calculating eth_tx_hash bug by enable compatible_chain_id
- [x] update env config in web3 api-server:
   - remove the `chain_Id` env
   - add `compatible_chain_id` instead
   - and calculating chain_id with creator_id and compatible_chain_id