### PR TITLE
chore: allow ci to build for new commit in ghcr

### DIFF
--- a/.github/workflows/docker-publish-indexer.yml
+++ b/.github/workflows/docker-publish-indexer.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}${{ github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
 
+      - name: Get Current Commit Id
+        id: commit
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: New Commit Build => Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
@@ -53,7 +57,7 @@ jobs:
           file: docker/indexer/Dockerfile
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ steps.commit.outputs.sha_short }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/.github/workflows/docker-publish-indexer.yml
+++ b/.github/workflows/docker-publish-indexer.yml
@@ -2,18 +2,17 @@ name: Docker
 
 on:
   push:
-    branches: [ main, hot-fix ]
+    branches: [main, hot-fix, compatibility-breaking-changes]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [ main, hot-fix ]
+    branches: [main, hot-fix, compatibility-breaking-changes]
 
 env:
   # Use docker.io for Docker Hub if empty
-  REGISTRY: ${{ github.repository_owner != 'nervosnetwork' && 'ghcr.io/' || '' }}
+  REGISTRY: ${{ github.ref_type != 'tag' && 'ghcr.io/' || '' }}
   # github.repository as <account>/<repo>
   IMAGE_NAME: godwoken-web3-indexer-prebuilds
-
 
 jobs:
   docker-build-push:
@@ -25,7 +24,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       # The GHP_CRT secret is password or personal access token with `write:packages` access scope
@@ -34,8 +33,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.GHP_CRT }}
+          username: ${{ github.ref_type != 'tag' && github.actor || secrets.DOCKERHUB_USERNAME }}
+          password: ${{ github.ref_type != 'tag' && secrets.GHP_CRT || secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -47,8 +46,8 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-        if: ${{ github.repository_owner != 'nervosnetwork'}}
+      - name: New Commit Build => Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+        if: ${{ github.ref_type != 'tag' }}
         uses: docker/build-push-action@v2
         with:
           file: docker/indexer/Dockerfile
@@ -59,7 +58,7 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # only for new tag
-      - name: Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-web3-indexer-prebuilds
+      - name: Official Release Build => Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-web3-indexer-prebuilds
         if: ${{ github.repository_owner == 'nervosnetwork' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-publish-indexer.yml
+++ b/.github/workflows/docker-publish-indexer.yml
@@ -42,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}${{ github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}${{ startsWith(github.ref, 'refs/tags') && github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
 
       - name: Get Current Commit Id
         id: commit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}${{ github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
 
+      - name: Get Current Commit Id
+        id: commit
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: New Commit Build => Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
@@ -52,7 +56,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ steps.commit.outputs.sha_short }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,18 +2,17 @@ name: Docker
 
 on:
   push:
-    branches: [ main, hot-fix ]
+    branches: [main, hot-fix, compatibility-breaking-changes]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [ main, hot-fix ]
+    branches: [main, hot-fix, compatibility-breaking-changes]
 
 env:
   # Use docker.io for Docker Hub if empty
-  REGISTRY: ${{ github.repository_owner != 'nervosnetwork' && 'ghcr.io/' || '' }}
+  REGISTRY: ${{ github.ref_type != 'tag' && 'ghcr.io/' || '' }}
   # github.repository as <account>/<repo>
   IMAGE_NAME: godwoken-web3-prebuilds
-
 
 jobs:
   docker-build-push:
@@ -25,7 +24,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       # The GHP_CRT secret is password or personal access token with `write:packages` access scope
@@ -34,8 +33,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.GHP_CRT }}
+          username: ${{ github.ref_type != 'tag' && github.actor || secrets.DOCKERHUB_USERNAME }}
+          password: ${{ github.ref_type != 'tag' && secrets.GHP_CRT || secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -47,8 +46,8 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-        if: ${{ github.repository_owner != 'nervosnetwork'}}
+      - name: New Commit Build => Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+        if: ${{ github.ref_type != 'tag' }}
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -58,7 +57,7 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # only for new tag
-      - name: Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-web3-prebuilds
+      - name: Official Release Build => Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-web3-prebuilds
         if: ${{ github.repository_owner == 'nervosnetwork' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}${{ github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}${{ startsWith(github.ref, 'refs/tags') && github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
 
       - name: Get Current Commit Id
         id: commit


### PR DESCRIPTION
- [x] tweak ci to enable two kinds build:
  - new-commit-build: for `ghcr.io` aka github packages, make ci build image every time we push new commit to branch.
  - official-release-build: for docker image, make ci build image only when we release new tag.
- [x] use current commit id as part of the image tag in new-commit-build

requirement:
 - `secrets.GHP_CRT`