### PR TITLE
fix: distinct zero address and deploy to address

### DIFF
--- a/packages/api-server/src/base/address.ts
+++ b/packages/api-server/src/base/address.ts
@@ -3,6 +3,8 @@ import { GodwokenClient, RawL2Transaction } from "@godwoken-web3/godwoken";
 import { envConfig } from "./env-config";
 import { Uint32 } from "./types/uint";
 
+const ZERO_ETH_ADDRESS = "0x" + "00".repeat(20);
+
 class EthToGwArgsBuilder {
   private method: number;
   private ethAddress: HexString;
@@ -14,6 +16,12 @@ class EthToGwArgsBuilder {
 
     if (!ethAddress.startsWith("0x")) {
       throw new Error("Eth address must starts with 0x prefix");
+    }
+
+    if (ethAddress === ZERO_ETH_ADDRESS) {
+      throw new Error(
+        `zero address ${ZERO_ETH_ADDRESS} has no valid script hash!`
+      );
     }
 
     this.method = method;
@@ -73,8 +81,14 @@ export async function ethAddressToAccountId(
   ethAddress: HexString,
   godwokenClient: GodwokenClient
 ): Promise<number | undefined> {
-  if (ethAddress === "0x0000000000000000000000000000000000000000") {
+  if (ethAddress === "0x") {
     return +envConfig.creatorAccountId;
+  }
+
+  if (ethAddress === ZERO_ETH_ADDRESS) {
+    throw new Error(
+      `zero address ${ZERO_ETH_ADDRESS} has no valid account_id!`
+    );
   }
 
   const scriptHash: Hash | undefined = await ethAddressToScriptHash(

--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -6,7 +6,7 @@ import * as secp256k1 from "secp256k1";
 import { ethAddressToAccountId } from "./base/address";
 import { envConfig } from "./base/env-config";
 
-export const EMPTY_ETH_ADDRESS = "0x" + "00".repeat(20);
+export const DEPLOY_TO_ADDRESS = "0x";
 
 export interface PolyjuiceTransaction {
   nonce: HexNumber;
@@ -134,17 +134,7 @@ async function parseRawTransactionData(
   rawTx: PolyjuiceTransaction,
   rpc: GodwokenClient
 ) {
-  const {
-    nonce,
-    gasPrice,
-    gasLimit,
-    to: toA,
-    value,
-    data,
-    v,
-    r: rA,
-    s: sA,
-  } = rawTx;
+  const { nonce, gasPrice, gasLimit, to, value, data, v, r: rA, s: sA } = rawTx;
   const r = "0x" + rA.slice(2).padStart(64, "0");
   const s = "0x" + sA.slice(2).padStart(64, "0");
 
@@ -152,8 +142,6 @@ async function parseRawTransactionData(
   if (+v % 2 === 0) {
     real_v = "0x01";
   }
-
-  const to = toA === "0x" ? EMPTY_ETH_ADDRESS : toA;
 
   const signature = r + s.slice(2) + real_v.slice(2);
 
@@ -194,7 +182,7 @@ async function parseRawTransactionData(
 
   let args_7 = "";
   let toId: HexNumber | undefined;
-  if (to === EMPTY_ETH_ADDRESS) {
+  if (to === DEPLOY_TO_ADDRESS) {
     args_7 = "0x03";
     toId = "0x" + BigInt(envConfig.creatorAccountId).toString(16);
   } else {
@@ -203,7 +191,7 @@ async function parseRawTransactionData(
   }
 
   if (toId == null) {
-    throw new Error(`to id not found by address: ${toA}`);
+    throw new Error(`to id not found by address: ${to}`);
   }
 
   const args =

--- a/packages/api-server/src/filter-web3-tx.ts
+++ b/packages/api-server/src/filter-web3-tx.ts
@@ -17,7 +17,7 @@ import { Uint128, Uint32, Uint64 } from "./base/types/uint";
 import { PolyjuiceSystemLog, PolyjuiceUserLog } from "./base/types/gw-log";
 import {
   CKB_SUDT_ID,
-  DEFAULT_EMPTY_ETH_ADDRESS,
+  ZERO_ETH_ADDRESS,
   DEFAULT_LOGS_BLOOM,
   POLYJUICE_SYSTEM_LOG_FLAG,
   POLYJUICE_USER_LOG_FLAG,
@@ -136,10 +136,7 @@ export async function filterWeb3Transaction(
     const logInfo = parsePolyjuiceSystemLog(polyjuiceSystemLog.data);
 
     let contractAddress = undefined;
-    if (
-      polyjuiceArgs.isCreate &&
-      logInfo.createdAddress !== DEFAULT_EMPTY_ETH_ADDRESS
-    ) {
+    if (polyjuiceArgs.isCreate && logInfo.createdAddress !== ZERO_ETH_ADDRESS) {
       contractAddress = logInfo.createdAddress;
     }
 

--- a/packages/api-server/src/methods/constant.ts
+++ b/packages/api-server/src/methods/constant.ts
@@ -4,7 +4,7 @@ export const POLY_MAX_TRANSACTION_GAS_LIMIT = 12500000;
 export const POLY_MIN_GAS_PRICE = 0;
 export const POLY_BLOCK_DIFFICULTY = BigInt("2500000000000000");
 
-export const DEFAULT_EMPTY_ETH_ADDRESS = `0x${"0".repeat(40)}`;
+export const ZERO_ETH_ADDRESS = `0x${"0".repeat(40)}`;
 export const DEFAULT_LOGS_BLOOM = "0x" + "00".repeat(256);
 
 export const POLYJUICE_SYSTEM_PREFIX = 255;

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -192,7 +192,7 @@ export class Eth {
       validators.blockParameter,
     ]);
     this.estimateGas = middleware(this.estimateGas.bind(this), 1, [
-      validators.ethCallParams,
+      validators.ethEstimateGasParams,
     ]);
     this.newFilter = middleware(this.newFilter.bind(this), 1, [
       validators.newFilterParams,
@@ -518,9 +518,15 @@ export class Eth {
     }
   }
 
-  async estimateGas(args: [TransactionCallObject]): Promise<HexNumber> {
+  async estimateGas(
+    args: [Partial<TransactionCallObject>]
+  ): Promise<HexNumber> {
     try {
       const txCallObj = args[0];
+
+      if (txCallObj.to == null) {
+        txCallObj.to = "0x";
+      }
 
       const extraGas: bigint = BigInt(envConfig.extraEstimateGas || "0");
 
@@ -540,7 +546,7 @@ export class Eth {
       let runResult;
       try {
         runResult = await ethCallTx(
-          txCallObj,
+          txCallObj as TransactionCallObject,
           this.rpc,
           this.ethWallet,
           undefined

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -78,8 +78,8 @@ const Config = require("../../../config/eth.json");
 type U32 = number;
 type U64 = bigint;
 
-const EMPTY_ADDRESS = "0x" + "00".repeat(20);
-const EMPTY_TX_HASH = "0x" + "00".repeat(32);
+const ZERO_ETH_ADDRESS = "0x" + "00".repeat(20);
+const ZERO_TX_HASH = "0x" + "00".repeat(32);
 
 type GodwokenBlockParameter = U64 | undefined;
 
@@ -276,7 +276,7 @@ export class Eth {
    * 20 bytes 0 hex string as the second argument.
    */
   coinbase(args: []): Address {
-    return EMPTY_ADDRESS;
+    return ZERO_ETH_ADDRESS;
   }
 
   /**
@@ -1050,7 +1050,7 @@ export class Eth {
       logs.map(async (log) => {
         const ethTxHash =
           (await this.gwTxHashToEthTxHash(log.transaction_hash)) ||
-          EMPTY_TX_HASH;
+          ZERO_TX_HASH;
         return toApiLog(log, ethTxHash);
       })
     );
@@ -1081,7 +1081,7 @@ export class Eth {
           logs.map(async (log) => {
             const ethTxHash =
               (await this.gwTxHashToEthTxHash(log.transaction_hash)) ||
-              EMPTY_TX_HASH;
+              ZERO_TX_HASH;
             return toApiLog(log, ethTxHash);
           })
         );
@@ -1103,7 +1103,7 @@ export class Eth {
         logs.map(async (log) => {
           const ethTxHash =
             (await this.gwTxHashToEthTxHash(log.transaction_hash)) ||
-            EMPTY_TX_HASH;
+            ZERO_TX_HASH;
           return toApiLog(log, ethTxHash);
         })
       );
@@ -1357,7 +1357,7 @@ async function ethCallTx(
   isEthWallet: boolean,
   blockNumber?: U64
 ): Promise<RunResult> {
-  const toAddress = txCallObj.to || "0x" + "00".repeat(20);
+  const toAddress = txCallObj.to;
 
   // if eth wallet mode, and `toAddress` not in allow list, reject.
   if (isEthWallet && !allowedAddresses.has(toAddress.toLowerCase())) {
@@ -1378,7 +1378,7 @@ async function buildEthCallTx(
   rpc: GodwokenClient
 ): Promise<RawL2Transaction> {
   const fromAddress = txCallObj.from || envConfig.defaultFromAddress;
-  const toAddress = txCallObj.to || "0x" + "00".repeat(20);
+  const toAddress = txCallObj.to;
   const gas = txCallObj.gas || "0x1000000";
   const gasPrice = txCallObj.gasPrice || "0x1";
   const value = txCallObj.value || "0x0";

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -136,7 +136,6 @@ export const validators = {
     return undefined;
   },
 
-  //TODO: estimateGas `to` is optional
   ethCallParams(params: any[], index: number): any {
     const targetParam = params[index];
     if (typeof targetParam !== "object") {
@@ -154,6 +153,70 @@ export const validators = {
     if (to == null) {
       return invalidParamsError(index, `to address is null!`);
     }
+
+    // validate `to`
+    if (to !== undefined && to !== null) {
+      const toErr = verifyAddress(to, index);
+      if (toErr !== undefined) {
+        return toErr;
+      }
+    }
+
+    // validate `from`
+    if (from !== undefined && from !== null) {
+      const fromErr = verifyAddress(from, index);
+      if (fromErr !== undefined) {
+        return fromErr;
+      }
+    }
+
+    // validate `gas`
+    if (gas !== undefined && gas !== null) {
+      const gasErr = verifyHexNumber(gas, index);
+      if (gasErr !== undefined) {
+        return gasErr;
+      }
+    }
+
+    // validate `gasLimit`
+    if (gasLimit !== undefined && gasLimit !== null) {
+      const gasLimitErr = verifyHexNumber(gasLimit, index);
+      if (gasLimitErr !== undefined) {
+        return gasLimitErr;
+      }
+    }
+
+    // validate `value`
+    if (value !== undefined && value !== null) {
+      const valueErr = verifyHexNumber(value, index);
+      if (valueErr !== undefined) {
+        return valueErr;
+      }
+    }
+
+    // validate `data`
+    if (data !== undefined && data !== null) {
+      const dataErr = verifyHexString(data, index);
+      if (dataErr !== undefined) {
+        return dataErr;
+      }
+    }
+
+    return undefined;
+  },
+
+  ethEstimateGasParams(params: any[], index: number): any {
+    const targetParam = params[index];
+    if (typeof targetParam !== "object") {
+      return invalidParamsError(index, `argument must be an object`);
+    }
+
+    const from = targetParam.from;
+    const to = targetParam.to;
+    const gas = targetParam.gas;
+    const gasLimit = targetParam.gasLimit;
+    const value = targetParam.value;
+    const data = targetParam.data;
 
     // validate `to`
     if (to !== undefined && to !== null) {

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -150,6 +150,11 @@ export const validators = {
     const value = targetParam.value;
     const data = targetParam.data;
 
+    // to is required
+    if (to == null) {
+      return invalidParamsError(index, `to address is null!`);
+    }
+
     // validate `to`
     if (to !== undefined && to !== null) {
       const toErr = verifyAddress(to, index);


### PR DESCRIPTION
- [x] fix the bug in which the zero address(0x0000....) of to_address is falsely treated as contract deployment before
- [x] validate the required to_address in eth_call params.
- [x] validate the optional to_address in eth_estimateGas params.  

---
after this pr, when you call eth_estimateGas for contract deployment (no to_address), the rpc will work as exepectd:
```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "eth_estimateGas",
    "params": [
        {
            "from": "0xFb2C72d3ffe10Ef7c9960272859a23D24db9e04A",
            "value": "0x1",
            "data": "0x6080604052607b60008190555060c68061001a6000396000f3fe60806040526004361060265760003560e01c806360fe47b114602b5780636d4ce63c146056575b600080fd5b605460048036036020811015603f57600080fd5b8101908080359060200190929190505050607e565b005b348015606157600080fd5b5060686088565b6040518082815260200191505060405180910390f35b8060008190555050565b6000805490509056fea265627a7a7231582001528e3c7dc7db53b0434c7bd349b2eb25952284d11bddc8f51bfac5522eabf764736f6c63430005100032"
        },
        "latest"
    ]
}
```

```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0x4e73"
}
```