### PR TITLE
fix: return clear error when transfering eoa to eoa in related RPCs

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,18 +4,18 @@
 
 ### Transfer Value From EOA To EOA
 
-since there is no native token in Godwoken Polyjuice(while Ethereum has ETH as its native token), we disable transferring value from eoa to eoa ability in the Polyjuice EVM.
+Since there is no native token in Godwoken Polyjuice(while Ethereum has ETH as its native token), we disable transferring value from EOA to EOA ability in Polyjuice EVM.
 
-result:
+### Result
 
 - in the following RPCs, to_address parameter **CAN NOT** be EOA address:
   - eth_call
   - eth_estimateGas
   - eth_sendRawTransaction
 
-recommend workaround:
+#### Recommend workaround
 
-- use Erc20 contract transfer function for transferring the token you want
+- Use the `transfer function` in [CKB_ERC20_Proxy](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract [combined](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b322/solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol#L154) with sUDT_ID = 1 (CKB a.k.a. pETH).
 
 ## EVM compatibility
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,18 @@
+# Eth Compatibility
+
+## RPC compatibility
+
+### Transfer Value From EOA To EOA
+
+due to security reason for Godwoken, we disable transferring value from eoa to eoa ability in the Polyjuice EVM.
+
+result:
+
+- in the following RPCs, to_address parameter **CAN NOT** be EOA address:
+  - eth_call
+  - eth_estimateGas
+  - eth_sendRawTransaction
+
+## EVM compatibility
+
+- [Godwoken-Polyjuice](https://github.com/nervosnetwork/godwoken-polyjuice/blob/compatibility-breaking-changes/docs/EVM-compatible.md)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,7 +4,7 @@
 
 ### Transfer Value From EOA To EOA
 
-due to security reason for Godwoken, we disable transferring value from eoa to eoa ability in the Polyjuice EVM.
+since there is no native token in Godwoken Polyjuice(while Ethereum has ETH as its native token), we disable transferring value from eoa to eoa ability in the Polyjuice EVM.
 
 result:
 
@@ -12,6 +12,10 @@ result:
   - eth_call
   - eth_estimateGas
   - eth_sendRawTransaction
+
+recommend workaround:
+
+- use Erc20 contract transfer function for transferring the token you want
 
 ## EVM compatibility
 

--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -3,8 +3,12 @@ import { GodwokenClient } from "@godwoken-web3/godwoken";
 import { rlp } from "ethereumjs-util";
 import keccak256 from "keccak256";
 import * as secp256k1 from "secp256k1";
-import { ethAddressToAccountId } from "./base/address";
+import {
+  ethAddressToAccountId,
+  ethEoaAddressToScriptHash,
+} from "./base/address";
 import { envConfig } from "./base/env-config";
+import { COMPATIBLE_DOCS_URL } from "./methods/constant";
 
 export const EMPTY_ETH_ADDRESS = "0x" + "00".repeat(20);
 
@@ -204,6 +208,15 @@ async function parseRawTransactionData(
 
   if (toId == null) {
     throw new Error(`to id not found by address: ${toA}`);
+  }
+
+  // disable to address is eoa case
+  const toScriptHash = await rpc.getScriptHash(Number(toId));
+  const eoaScriptHash = ethEoaAddressToScriptHash(to);
+  if (toScriptHash === eoaScriptHash) {
+    throw new Error(
+      `to_address can not be EOA address! more info: ${COMPATIBLE_DOCS_URL}`
+    );
   }
 
   const args =

--- a/packages/api-server/src/methods/constant.ts
+++ b/packages/api-server/src/methods/constant.ts
@@ -20,4 +20,7 @@ export const POLYJUICE_USER_LOG_FLAG = "0x3";
 
 export const HEADER_NOT_FOUND_ERR_MESSAGE = "header not found";
 
+export const COMPATIBLE_DOCS_URL =
+  "https://github.com/nervosnetwork/godwoken-web3/blob/compatibility-breaking-changes/docs/compatibility.md";
+
 export const QUERY_OFFSET_REACHED_END = "query offset reached end";

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -2,6 +2,7 @@
 
 import abiCoder, { AbiCoder } from "web3-eth-abi";
 import { FailedReason } from "../base/types/api";
+import { COMPATIBLE_DOCS_URL } from "./constant";
 import { RpcError } from "./error";
 import { GW_RPC_REQUEST_ERROR } from "./error-code";
 import { LogItem, PolyjuiceSystemLog } from "./types";
@@ -47,6 +48,11 @@ export function parseGwError(error: any): GwErrorDetail {
   if (message.startsWith(prefix)) {
     const jsonErr = message.slice(prefix.length);
     const err = JSON.parse(jsonErr);
+
+    if (err.data == null) {
+      parseGwRpcError(error);
+    }
+
     let polyjuiceSystemLog: PolyjuiceSystemLog | undefined;
     if (err.data.last_log) {
       polyjuiceSystemLog = parsePolyjuiceSystemLog(err.data.last_log);
@@ -111,7 +117,10 @@ export function parseGwRpcError(error: any): void {
 
     // can't find backend by script hash error
     if (err.message?.startsWith("can't find backend for script_hash")) {
-      throw new RpcError(err.code, "to address is not a valid contract.");
+      throw new RpcError(
+        err.code,
+        `to address is not a valid contract. more info: ${COMPATIBLE_DOCS_URL}`
+      );
     }
 
     throw new RpcError(err.code, err.message);


### PR DESCRIPTION
- [x] fix bug for parsing `can't find backend script hash` bug in `eth_call` and `eth_estimateGas`
- [x] disable transferrning from eoa to eoa in `eth_sendRawTransaction` 
- [x] add compatibility doc. 