### PR TITLE
feat: add cache for ethAddressToScriptHash

### DIFF
--- a/packages/api-server/src/cache/store.ts
+++ b/packages/api-server/src/cache/store.ts
@@ -57,10 +57,11 @@ export class Store {
     value: string | number,
     expiredTimeMilSecs?: number
   ) {
-    const setOptions = {
-      ...this.setOptions,
-      PX: expiredTimeMilSecs || this.setOptions.PX,
-    };
+    let setOptions = this.setOptions;
+    const PX = expiredTimeMilSecs || this.setOptions.PX;
+    if (PX) {
+      setOptions.PX = PX;
+    }
 
     return await this.client.set(key, value.toString(), setOptions);
   }


### PR DESCRIPTION
- [x] fix a bug in `Store` class when enable_expired set to false
- [x] add simple cache for `ethAddressToScriptHash` function
   - noticed that since the ethAddressToScriptHash mapping is not changeable, we set the cache in redis to have no expired time.