### PR TITLE
feat: add cache for eth_call rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ REDIS_URL=redis://user:password@localhost:6379 <redis url, optional, default to 
 PG_POOL_MAX=<pg pool max count, optional, default to 20>
 GAS_PRICE_CACHE_SECONDS=<seconds, optional, default to 0, and 0 means no cache>
 EXTRA_ESTIMATE_GAS=<eth_estimateGas will add this number to result, optional, default to 0>
+ENABLE_CACHE_ETH_CALL=<optional, enable eth_call cache, default to false>
 EOF
 
 $ yarn

--- a/packages/api-server/src/base/env-config.ts
+++ b/packages/api-server/src/base/env-config.ts
@@ -31,6 +31,7 @@ export const envConfig = {
   sentryDns: getOptional("SENTRY_DNS"),
   sentryEnvironment: getOptional("SENTRY_ENVIRONMENT"),
   godwokenReadonlyJsonRpc: getOptional("GODWOKEN_READONLY_JSON_RPC"),
+  enableCacheEthCall: getOptional("ENABLE_CACHE_ETH_CALL"),
 };
 
 function getRequired(name: string): string {

--- a/packages/api-server/src/cache/data.ts
+++ b/packages/api-server/src/cache/data.ts
@@ -1,0 +1,292 @@
+import { createClient } from "redis";
+import { envConfig } from "../base/env-config";
+import crypto from "crypto";
+
+// init publisher redis client
+export const pubClient = createClient({
+  url: envConfig.redisUrl,
+});
+pubClient.connect();
+pubClient.on("error", (err) => console.log("Redis Client Error", err));
+
+// init subscriber redis client
+export const subClient = createClient({
+  url: envConfig.redisUrl,
+});
+subClient.connect();
+subClient.on("error", (err) => console.log("Redis Client Error", err));
+
+export const SUB_TIME_OUT_MS = 2 * 1000; // 2s;
+export const LOCK_KEY_EXPIRED_TIME_OUT_MS = 60 * 1000; // 60s, the max tolerate timeout for execute call
+export const DATA_KEY_EXPIRED_TIME_OUT_MS = 5 * 60 * 1000; // 5 minutes
+export const POLL_INTERVAL_MS = 50; // 50ms
+export const POLL_TIME_OUT_MS = 2 * 60 * 1000; // 2 minutes
+
+export const DEFAULT_PREFIX_NAME = "defaultDataCache";
+export const DEFAULT_IS_ENABLE_LOCK = true;
+
+export interface DataCacheConstructor {
+  rawDataKey: string;
+  executeCallResult: ExecuteCallResult;
+  prefixName?: string;
+  isLockEnable?: boolean;
+  lock?: Partial<RedisLock>;
+  dataKeyExpiredTimeOutMs?: number;
+}
+
+export type ExecuteCallResult = () => Promise<string>;
+
+export interface RedisLock {
+  key: LockKey;
+  subscribe: RedSubscribe;
+  pollIntervalMs: number;
+  pollTimeOutMs: number;
+}
+
+export interface LockKey {
+  name: string;
+  expiredTimeMs: number;
+}
+
+export interface RedSubscribe {
+  channel: string;
+  timeOutMs: number;
+}
+
+export class RedisDataCache {
+  public prefixName: string;
+  public rawDataKey: string; // unique part of dataKey
+  public dataKey: string; // real dataKey saved on redis combined from rawDataKey with prefix name and so on.
+  public lock: RedisLock | undefined;
+  public dataKeyExpiredTimeOut: number;
+  public executeCallResult: ExecuteCallResult;
+
+  constructor(args: DataCacheConstructor) {
+    this.prefixName = args.prefixName || DEFAULT_PREFIX_NAME;
+    this.rawDataKey = args.rawDataKey;
+    this.dataKey = `${this.prefixName}:key:${this.rawDataKey}`;
+    this.executeCallResult = args.executeCallResult;
+    this.dataKeyExpiredTimeOut =
+      args.dataKeyExpiredTimeOutMs || DATA_KEY_EXPIRED_TIME_OUT_MS;
+
+    const isLockEnable = args.isLockEnable ?? DEFAULT_IS_ENABLE_LOCK; // default is true;
+    if (isLockEnable) {
+      this.lock = {
+        key: {
+          name:
+            args.lock?.key?.name ||
+            `${this.prefixName}:lock:${this.rawDataKey}`,
+          expiredTimeMs:
+            args.lock?.key?.expiredTimeMs || LOCK_KEY_EXPIRED_TIME_OUT_MS,
+        },
+        subscribe: {
+          channel:
+            args.lock?.subscribe?.channel ||
+            `${this.prefixName}:channel:${this.rawDataKey}`,
+          timeOutMs: args.lock?.subscribe?.timeOutMs || SUB_TIME_OUT_MS,
+        },
+        pollIntervalMs: args.lock?.pollIntervalMs || POLL_INTERVAL_MS,
+        pollTimeOutMs: args.lock?.pollTimeOutMs || POLL_TIME_OUT_MS,
+      };
+    }
+  }
+
+  async get() {
+    const dataKey = this.dataKey;
+    const value = await pubClient.get(dataKey);
+    if (value !== null) {
+      console.debug(
+        `[${this.constructor.name}]: hit cache via Redis.Get, key: ${dataKey}`
+      );
+      return value;
+    }
+
+    const setDataKeyOptions = { PX: this.dataKeyExpiredTimeOut };
+
+    if (this.lock == undefined) {
+      const result = await this.executeCallResult();
+      // set data cache
+      await pubClient.set(dataKey, result, setDataKeyOptions);
+      return result;
+    }
+
+    // use redis-lock for data cache
+    const t1 = new Date();
+    const lockValue = getLockUniqueValue();
+    const setLockKeyOptions = {
+      NX: true,
+      PX: this.lock.key.expiredTimeMs,
+    };
+
+    const releaseLock = async (lockValue: string) => {
+      if (!this.lock) throw new Error("enable lock first!");
+
+      const value = await pubClient.get(this.lock.key.name);
+      if (value === lockValue) {
+        // only lock owner can delete the lock
+        const delNumber = await pubClient.del(this.lock.key.name);
+        console.debug(
+          `[${this.constructor.name}]: delete key ${this.lock.key.name}, result: ${delNumber}`
+        );
+      }
+    };
+
+    while (true) {
+      const value = await pubClient.get(dataKey);
+      if (value !== null) {
+        console.debug(
+          `[${this.constructor.name}]: hit cache via Redis.Get, key: ${dataKey}`
+        );
+        return value;
+      }
+
+      const isLockAcquired = await pubClient.set(
+        this.lock.key.name,
+        lockValue,
+        setLockKeyOptions
+      );
+
+      if (isLockAcquired) {
+        try {
+          const result = await this.executeCallResult();
+          // set data cache
+          await pubClient.set(dataKey, result, setDataKeyOptions);
+          // publish the result to channel
+          const publishResult = successResult(result);
+          const totalSubs = await pubClient.publish(
+            this.lock.subscribe.channel,
+            publishResult
+          );
+          console.debug(
+            `[${this.constructor.name}][success]: publish message ${publishResult} on channel ${this.lock.subscribe.channel}, total subscribers: ${totalSubs}`
+          );
+          await releaseLock(lockValue);
+          return result;
+        } catch (error: any) {
+          const reason = error.message;
+          if (!reason.includes("request to")) {
+            // publish the non-network-connecting-error-result to channel
+            const publishResult = errorResult(reason);
+            const totalSubs = await pubClient.publish(
+              this.lock.subscribe.channel,
+              publishResult
+            );
+            console.debug(
+              `[${this.constructor.name}][error]: publish message ${publishResult} on channel ${this.lock.subscribe.channel}, total subscribers: ${totalSubs}`
+            );
+          }
+          await releaseLock(lockValue);
+          throw new Error(error.message);
+        }
+      }
+
+      // if lock is not acquired
+      try {
+        const result = await this.subscribe();
+        console.debug(
+          `[${this.constructor.name}]: hit cache via Redis.Subscribe, key: ${dataKey}`
+        );
+        return result;
+      } catch (error: any) {
+        if (
+          !JSON.stringify(error).includes(
+            "subscribe channel for message time out"
+          )
+        ) {
+          console.debug(
+            `[${this.constructor.name}]: subscribe err:`,
+            error.message
+          );
+          throw new Error(error.message);
+        }
+      }
+
+      // check if poll time out
+      const t2 = new Date();
+      const diff = t2.getTime() - t1.getTime();
+      if (diff > this.lock.pollTimeOutMs) {
+        throw new Error(
+          `poll data value from cache layer time out ${this.lock.pollTimeOutMs}`
+        );
+      }
+
+      await asyncSleep(this.lock.pollIntervalMs);
+    }
+  }
+
+  async subscribe() {
+    if (this.lock == undefined) {
+      throw new Error(`enable redis lock first!`);
+    }
+
+    const p = new Promise((resolve, reject) => {
+      subClient.subscribe(
+        this.lock!.subscribe.channel,
+        async (message: string) => {
+          try {
+            const data = parseExecuteResult(message);
+            await subClient.unsubscribe(this.lock!.subscribe.channel);
+            return resolve(data);
+          } catch (error) {
+            return reject(error);
+          }
+        }
+      );
+    });
+
+    const t = new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        subClient.unsubscribe(this.lock!.subscribe.channel);
+        return reject(
+          `subscribe channel for message time out ${this.lock?.subscribe.timeOutMs}`
+        );
+      }, this.lock?.subscribe.timeOutMs);
+    });
+
+    return (await Promise.race([p, t])) as Promise<string>;
+  }
+}
+
+export function getLockUniqueValue() {
+  return "0x" + crypto.randomBytes(20).toString("hex");
+}
+
+export enum PublishExecuteResultStatus {
+  Success,
+  Error,
+}
+
+export interface PublishExecuteResult {
+  status: PublishExecuteResultStatus;
+  data?: string;
+  err?: string;
+}
+
+export function successResult(result: string) {
+  const res: PublishExecuteResult = {
+    status: PublishExecuteResultStatus.Success,
+    data: result,
+  };
+  return JSON.stringify(res);
+}
+
+export function errorResult(reason: string) {
+  const res: PublishExecuteResult = {
+    status: PublishExecuteResultStatus.Error,
+    err: reason,
+  };
+  return JSON.stringify(res);
+}
+
+export function parseExecuteResult(res: string) {
+  const jsonRes: PublishExecuteResult = JSON.parse(res);
+  if (jsonRes.status === PublishExecuteResultStatus.Success) {
+    return jsonRes.data!;
+  }
+
+  throw new Error("[RedisSubscribeResult]" + jsonRes.err);
+}
+
+const asyncSleep = async (ms = 0) => {
+  return new Promise((r) => setTimeout(() => r("ok"), ms));
+};

--- a/packages/godwoken/src/client.ts
+++ b/packages/godwoken/src/client.ts
@@ -158,6 +158,14 @@ export class GodwokenClient {
     return await this.rpcCall("get_node_info");
   }
 
+  public async getTipBlockHash(): Promise<HexString> {
+    return await this.rpcCall("get_tip_block_hash");
+  }
+
+  public async getMemPoolStateRoot(): Promise<HexString> {
+    return await this.rpcCall("get_mem_pool_state_root");
+  }
+
   private async rpcCall(methodName: string, ...args: any[]): Promise<any> {
     const name = "gw_" + methodName;
     try {


### PR DESCRIPTION
this PR is based on the `poly_executeRawL2Transaction` cache on main branch:

- [x] add cache for `eth_call` rpc
- [x] add a new env variable `ENABLE_CACHE_ETH_CALL` 

godwoken-tests releated pr: 

- https://github.com/nervosnetwork/godwoken-tests/pull/80