### PR TITLE
fix(eth_call): use default from_id instead of default_from_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ ROLLUP_TYPE_HASH=<godwoken rollup type hash>
 ROLLUP_CONFIG_HASH=<godwoken rollup config hash>
 COMPATIBLE_CHAIN_ID=<godwoken compatible chain id in integer>
 CREATOR_ACCOUNT_ID=<your creator account id in integer>
-DEFAULT_FROM_ADDRESS=<default from eth address>
 DEFAULT_FROM_ID=<default from eth address's godwoken account id>
 POLYJUICE_VALIDATOR_TYPE_HASH=<godwoken polyjuice validator type hash>
 L2_SUDT_VALIDATOR_SCRIPT_TYPE_HASH=<l2 sudt validator script type hash>
@@ -248,7 +247,7 @@ resource:
 
 ### poly
 - poly_getChainInfo
-- poly_getDefaultFromAddress
+- poly_getDefaultFromId
 - poly_getContractValidatorTypeHash
 - poly_getRollupTypeHash
 - poly_getRollupConfigHash

--- a/packages/api-server/src/base/env-config.ts
+++ b/packages/api-server/src/base/env-config.ts
@@ -14,7 +14,6 @@ export const envConfig = {
     +getRequired("CREATOR_ACCOUNT_ID"),
     +getRequired("COMPATIBLE_CHAIN_ID")
   ),
-  defaultFromAddress: getRequired("DEFAULT_FROM_ADDRESS"),
   defaultFromId: getRequired("DEFAULT_FROM_ID"),
   l2SudtValidatorScriptTypeHash: getRequired(
     "L2_SUDT_VALIDATOR_SCRIPT_TYPE_HASH"

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -1383,13 +1383,19 @@ async function buildEthCallTx(
   txCallObj: TransactionCallObject,
   rpc: GodwokenClient
 ): Promise<RawL2Transaction> {
-  const fromAddress = txCallObj.from || envConfig.defaultFromAddress;
+  const fromAddress = txCallObj.from;
   const toAddress = txCallObj.to;
   const gas = txCallObj.gas || "0x1000000";
   const gasPrice = txCallObj.gasPrice || "0x1";
   const value = txCallObj.value || "0x0";
   const data = txCallObj.data || "0x0";
   let fromId: number | undefined;
+
+  if (!fromAddress) {
+    fromId = +envConfig.defaultFromId;
+    console.log(`use default fromId: ${fromId}`);
+  }
+
   if (
     fromAddress != null &&
     fromAddress != undefined &&

--- a/packages/api-server/src/methods/modules/poly.ts
+++ b/packages/api-server/src/methods/modules/poly.ts
@@ -25,8 +25,8 @@ export class Poly {
   }
 
   // from in eth_call is optional, DEFAULT_FROM_ADDRESS fills it when empty
-  async getDefaultFromAddress(_args: []): Promise<Address> {
-    return envConfig.defaultFromAddress;
+  async getDefaultFromId(_args: []): Promise<Address> {
+    return envConfig.defaultFromId;
   }
 
   async getContractValidatorTypeHash(args: []): Promise<Hash> {


### PR DESCRIPTION
- [x] fix the bug when `env.defaultFromAddress` is not register in eoa-mapping contract so that when you send eth_call without from_address, the request will failed.
- [x] in order to simplify the env config for web3, remove the `env.defaultFromAddress`, only keep `env.defaultFromId`

releated issue:

- https://github.com/nervosnetwork/godwoken-web3/issues/210