### PR TITLE
refactor(validator): verify params with correct types and full context

### DIFF
--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -9,7 +9,7 @@ import {
 } from "./base/address";
 import { envConfig } from "./base/env-config";
 import { COMPATIBLE_DOCS_URL } from "./methods/constant";
-import { padErrorContext, verifyGasLimit } from "./methods/validator";
+import { verifyGasLimit } from "./methods/validator";
 
 export const DEPLOY_TO_ADDRESS = "0x";
 
@@ -150,8 +150,7 @@ async function parseRawTransactionData(
 
   const gasLimitErr = verifyGasLimit(gasLimit, 0);
   if (gasLimitErr) {
-    throw padErrorContext(
-      gasLimitErr,
+    throw gasLimitErr.padErrorContext(
       `eth_sendRawTransaction ${parseRawTransactionData.name}`
     );
   }

--- a/packages/api-server/src/convert-tx.ts
+++ b/packages/api-server/src/convert-tx.ts
@@ -150,7 +150,7 @@ async function parseRawTransactionData(
 
   const gasLimitErr = verifyGasLimit(gasLimit, 0);
   if (gasLimitErr) {
-    throw gasLimitErr.padErrorContext(
+    throw gasLimitErr.padContext(
       `eth_sendRawTransaction ${parseRawTransactionData.name}`
     );
   }
@@ -175,7 +175,9 @@ async function parseRawTransactionData(
   );
 
   if (fromId == null) {
-    throw new Error(`from id not found! fromEthAddress: ${fromEthAddress}`);
+    throw new Error(
+      `from id not found by from Address: ${fromEthAddress}, have you deposited?`
+    );
   }
 
   // header

--- a/packages/api-server/src/methods/error.ts
+++ b/packages/api-server/src/methods/error.ts
@@ -33,13 +33,11 @@ export class InvalidParamsError extends RpcError {
     super(INVALID_PARAMS, message);
   }
 
-  padErrorContext(context: string): InvalidParamsError {
+  padContext(context: string): InvalidParamsError {
     const msgs = this.message.split(/(invalid argument .: )/);
     // [ '', 'invalid argument <number>: ', 'message' ]
     if (msgs.length !== 3) {
-      throw new Error(
-        `parse InvalidParamsError message failed: ${this.message}, ${msgs}`
-      );
+      return this;
     }
     const newMsg = `${msgs[1]}${context} -> ${msgs[2]}`;
     this.message = newMsg;

--- a/packages/api-server/src/methods/error.ts
+++ b/packages/api-server/src/methods/error.ts
@@ -32,6 +32,19 @@ export class InvalidParamsError extends RpcError {
   constructor(message: string) {
     super(INVALID_PARAMS, message);
   }
+
+  padErrorContext(context: string): InvalidParamsError {
+    const msgs = this.message.split(/(invalid argument .: )/);
+    // [ '', 'invalid argument <number>: ', 'message' ]
+    if (msgs.length !== 3) {
+      throw new Error(
+        `parse InvalidParamsError message failed: ${this.message}, ${msgs}`
+      );
+    }
+    const newMsg = `${msgs[1]}${context} -> ${msgs[2]}`;
+    this.message = newMsg;
+    return this;
+  }
 }
 
 export class InternalError extends RpcError {

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -1399,7 +1399,7 @@ async function buildEthCallTx(
 
   const gasLimitErr = verifyGasLimit(gas, 0);
   if (gasLimitErr) {
-    throw gasLimitErr.padErrorContext(buildEthCallTx.name);
+    throw gasLimitErr.padContext(buildEthCallTx.name);
   }
 
   if (!fromAddress) {
@@ -1413,7 +1413,9 @@ async function buildEthCallTx(
   }
 
   if (fromId == null) {
-    throw new Error(`from id not found! fromAddress: ${fromAddress}`);
+    throw new Error(
+      `from id not found by from address: ${fromAddress}, have you deposited?`
+    );
   }
 
   const toId: number | undefined = await ethAddressToAccountId(toAddress, rpc);

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -8,12 +8,7 @@ import {
   SudtPayFeeLog,
   BlockParameter,
 } from "../types";
-import {
-  middleware,
-  padErrorContext,
-  validators,
-  verifyGasLimit,
-} from "../validator";
+import { middleware, validators, verifyGasLimit } from "../validator";
 import { FilterFlag, FilterObject } from "../../cache/types";
 import { HexNumber, Hash, Address, HexString } from "@ckb-lumos/base";
 import { RawL2Transaction, RunResult } from "@godwoken-web3/godwoken";
@@ -1404,7 +1399,7 @@ async function buildEthCallTx(
 
   const gasLimitErr = verifyGasLimit(gas, 0);
   if (gasLimitErr) {
-    throw padErrorContext(gasLimitErr, buildEthCallTx.name);
+    throw gasLimitErr.padErrorContext(buildEthCallTx.name);
   }
 
   if (!fromAddress) {

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -83,17 +83,7 @@ export const validators = {
    * @param {number} index index of parameter
    */
   blockHash(params: any[], index: number): any {
-    if (typeof params[index] !== "string") {
-      return invalidParamsError(index, `argument must be a hex string`);
-    }
-
-    const blockHash = params[index].substring(2);
-
-    if (!/^[0-9a-fA-F]+$/.test(blockHash) || blockHash.length !== 64) {
-      return invalidParamsError(index, `invalid block hash`);
-    }
-
-    return undefined;
+    return verifyBlockHash(params[index], index);
   },
 
   /**
@@ -102,17 +92,7 @@ export const validators = {
    * @param {number} index index of parameter
    */
   txHash(params: any[], index: number): any {
-    if (typeof params[index] !== "string") {
-      return invalidParamsError(index, `argument must be a hex string`);
-    }
-
-    const txHash = params[index].substring(2);
-
-    if (!/^[0-9a-fA-F]+$/.test(txHash) || txHash.length !== 64) {
-      return invalidParamsError(index, `invalid transaction hash`);
-    }
-
-    return undefined;
+    return verifyTxHash(params[index], index);
   },
 
   /**
@@ -130,258 +110,152 @@ export const validators = {
    * @param {number} index index of parameter
    */
   bool(params: any[], index: number): any {
-    if (typeof params[index] !== "boolean") {
-      return invalidParamsError(index, `argument is not boolean`);
-    }
-    return undefined;
+    return verifyBoolean(params[index], index);
   },
 
   ethCallParams(params: any[], index: number): any {
-    const targetParam = params[index];
-    if (typeof targetParam !== "object") {
-      return invalidParamsError(index, `argument must be an object`);
-    }
-
-    const from = targetParam.from;
-    const to = targetParam.to;
-    const gas = targetParam.gas;
-    const gasLimit = targetParam.gasLimit;
-    const value = targetParam.value;
-    const data = targetParam.data;
-
-    // to is required
-    if (to == null) {
-      return invalidParamsError(index, `to address is null!`);
-    }
-
-    // validate `to`
-    if (to !== undefined && to !== null) {
-      const toErr = verifyAddress(to, index);
-      if (toErr !== undefined) {
-        return toErr;
-      }
-    }
-
-    // validate `from`
-    if (from !== undefined && from !== null) {
-      const fromErr = verifyAddress(from, index);
-      if (fromErr !== undefined) {
-        return fromErr;
-      }
-    }
-
-    // validate `gas`
-    if (gas !== undefined && gas !== null) {
-      const gasErr = verifyHexNumber(gas, index);
-      if (gasErr !== undefined) {
-        return gasErr;
-      }
-    }
-
-    // validate `gasLimit`
-    if (gasLimit !== undefined && gasLimit !== null) {
-      const gasLimitErr = verifyHexNumber(gasLimit, index);
-      if (gasLimitErr !== undefined) {
-        return gasLimitErr;
-      }
-    }
-
-    // validate `value`
-    if (value !== undefined && value !== null) {
-      const valueErr = verifyHexNumber(value, index);
-      if (valueErr !== undefined) {
-        return valueErr;
-      }
-    }
-
-    // validate `data`
-    if (data !== undefined && data !== null) {
-      const dataErr = verifyHexString(data, index);
-      if (dataErr !== undefined) {
-        return dataErr;
-      }
-    }
-
-    return undefined;
+    return verifyEthCallObject(params[index], index);
   },
 
   ethEstimateGasParams(params: any[], index: number): any {
-    const targetParam = params[index];
-    if (typeof targetParam !== "object") {
-      return invalidParamsError(index, `argument must be an object`);
-    }
-
-    const from = targetParam.from;
-    const to = targetParam.to;
-    const gas = targetParam.gas;
-    const gasLimit = targetParam.gasLimit;
-    const value = targetParam.value;
-    const data = targetParam.data;
-
-    // validate `to`
-    if (to !== undefined && to !== null) {
-      const toErr = verifyAddress(to, index);
-      if (toErr !== undefined) {
-        return toErr;
-      }
-    }
-
-    // validate `from`
-    if (from !== undefined && from !== null) {
-      const fromErr = verifyAddress(from, index);
-      if (fromErr !== undefined) {
-        return fromErr;
-      }
-    }
-
-    // validate `gas`
-    if (gas !== undefined && gas !== null) {
-      const gasErr = verifyHexNumber(gas, index);
-      if (gasErr !== undefined) {
-        return gasErr;
-      }
-    }
-
-    // validate `gasLimit`
-    if (gasLimit !== undefined && gasLimit !== null) {
-      const gasLimitErr = verifyHexNumber(gasLimit, index);
-      if (gasLimitErr !== undefined) {
-        return gasLimitErr;
-      }
-    }
-
-    // validate `value`
-    if (value !== undefined && value !== null) {
-      const valueErr = verifyHexNumber(value, index);
-      if (valueErr !== undefined) {
-        return valueErr;
-      }
-    }
-
-    // validate `data`
-    if (data !== undefined && data !== null) {
-      const dataErr = verifyHexString(data, index);
-      if (dataErr !== undefined) {
-        return dataErr;
-      }
-    }
-
-    return undefined;
+    return verifyEstimateGasCallObject(params[index], index);
   },
 
   newFilterParams(params: any[], index: number): any {
-    const targetParam = params[index];
-    if (typeof targetParam !== "object") {
-      return invalidParamsError(index, `argument must be an object`);
-    }
-
-    const fromBlock = targetParam.fromBlock;
-    const toBlock = targetParam.toBlock;
-    const address = targetParam.address;
-    const topics = targetParam.topics;
-
-    // validate `fromBlock`
-    if (fromBlock !== undefined && fromBlock !== null) {
-      const fromBlockErr = verifyBlockParameter(fromBlock, index);
-      if (fromBlockErr !== undefined) {
-        return fromBlockErr;
-      }
-    }
-
-    // validate `toBlock`
-    if (toBlock !== undefined && toBlock !== null) {
-      const toBlockErr = verifyBlockParameter(toBlock, index);
-      if (toBlockErr !== undefined) {
-        return toBlockErr;
-      }
-    }
-
-    // validate `address`
-    if (address !== undefined && address !== null) {
-      if (Array.isArray(address)) {
-        for (const addr of address) {
-          const addressErr = verifyAddress(addr, index);
-          if (addressErr !== undefined) {
-            return addressErr;
-          }
-        }
-      } else {
-        const addressErr = verifyAddress(address, index);
-        if (addressErr !== undefined) {
-          return addressErr;
-        }
-      }
-    }
-
-    // validate `topics`
-    if (topics !== undefined && topics !== null) {
-      if (!Array.isArray(topics)) {
-        return invalidParamsError(index, `argument must be an array`);
-      }
-      for (const topic of topics) {
-        verifyFilterTopic(topic, index);
-      }
-    }
-
-    return undefined;
+    return verifyNewFilterObj(params[index], index);
   },
 };
 
-function verifyAddress(address: any, index: number): any {
-  if (typeof address !== "string") {
-    return invalidParamsError(index, `argument must be a hex string`);
+//****** standalone verify function ********/
+export function verifyBoolean(
+  bool: any,
+  index: number
+): InvalidParamsError | undefined {
+  if (typeof bool !== "boolean") {
+    return invalidParamsError(index, `argument is not boolean`);
   }
+  return undefined;
+}
 
-  if (!validateAddress(address)) {
+export function verifyHexNumber(
+  hexNumber: string,
+  index: number
+): InvalidParamsError | undefined {
+  if (typeof hexNumber !== "string") {
     return invalidParamsError(
       index,
-      `address must be a 20 bytes-length hex string`
+      `hexNumber argument must be a string type`
+    );
+  }
+
+  if (!hexNumber.startsWith("0x")) {
+    return invalidParamsError(index, `hexNumber without 0x prefix`);
+  }
+
+  if (hexNumber.startsWith("0x0") && hexNumber !== "0x0") {
+    return invalidParamsError(index, `hexNumber with leading zero digits`);
+  }
+
+  if (!validateHexNumber(hexNumber)) {
+    return invalidParamsError(index, `invalid hexNumber token`);
+  }
+
+  return undefined;
+}
+
+export function verifyHexString(
+  hexString: any,
+  index: number
+): InvalidParamsError | undefined {
+  if (typeof hexString !== "string") {
+    return invalidParamsError(
+      index,
+      `hexString argument must be a string type`
+    );
+  }
+
+  if (!hexString.startsWith("0x")) {
+    return invalidParamsError(index, `hexString without 0x prefix`);
+  }
+
+  if (hexString.length % 2 !== 0) {
+    return invalidParamsError(index, `hexString must has even length`);
+  }
+
+  if (!validateHexString(hexString)) {
+    return invalidParamsError(index, `invalid hexString token`);
+  }
+
+  return undefined;
+}
+
+export function verifyAddress(
+  address: any,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyHexString(address, index);
+  if (err) {
+    return padErrorContext(err, "address");
+  }
+
+  if (address.substring(2).length !== 40) {
+    return invalidParamsError(
+      index,
+      `expect address has 20 bytes, but getting ${
+        address.substring(2).length / 2
+      } bytes`
     );
   }
 
   return undefined;
 }
 
-function verifyHexNumber(hexNumber: string, index: number) {
-  if (typeof hexNumber !== "string") {
-    return invalidParamsError(index, `argument must be a hex string`);
+export function verifyBlockHash(
+  blockHash: any,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyHexString(blockHash, index);
+  if (err) {
+    return padErrorContext(err, "blockHash");
   }
 
-  if (!hexNumber.startsWith("0x")) {
-    return invalidParamsError(index, `hex string without 0x prefix`);
-  }
-
-  if (hexNumber.startsWith("0x0") && hexNumber !== "0x0") {
-    return invalidParamsError(index, `hex number with leading zero digits`);
-  }
-
-  if (!validateHexNumber(hexNumber)) {
-    return invalidParamsError(index, `invalid hex number`);
-  }
-
-  return undefined;
-}
-
-function verifyStorageKey(key: string, index: number) {
-  if (typeof key !== "string") {
-    return invalidParamsError(index, `argument must be a hex string`);
-  }
-
-  if (!key.startsWith("0x")) {
-    return invalidParamsError(index, `hex string without 0x prefix`);
-  }
-
-  if (!/^0x([0-9a-fA-F]*)$/.test(key)) {
-    return invalidParamsError(index, `invalid hex`);
+  if (blockHash.substring(2).length !== 64) {
+    return invalidParamsError(
+      index,
+      `expect blockHash has 32 bytes, but getting ${
+        blockHash.substring(2).length / 2
+      } bytes`
+    );
   }
 
   return undefined;
 }
 
-function verifyBlockParameter(
+export function verifyTxHash(
+  txHash: any,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyHexString(txHash, index);
+  if (err) {
+    return padErrorContext(err, "txHash");
+  }
+
+  if (txHash.substring(2).length !== 64) {
+    return invalidParamsError(
+      index,
+      `expect txHash has 32 bytes, but getting ${
+        txHash.substring(2).length / 2
+      } bytes`
+    );
+  }
+
+  return undefined;
+}
+
+export function verifyBlockParameter(
   blockParameter: BlockParameter,
   index: number
-): any {
+): InvalidParamsError | undefined {
   if (
     blockParameter === "latest" ||
     blockParameter === "earliest" ||
@@ -390,44 +264,155 @@ function verifyBlockParameter(
     return undefined;
   }
 
-  if (typeof blockParameter !== "string") {
-    return invalidParamsError(
-      index,
-      `argument must be a hex number, "latest", "earliest" or "pending".`
-    );
-  }
-
-  return verifyHexNumber(blockParameter, index);
-}
-
-function verifyHexString(hexString: any, index: number): any {
-  if (typeof hexString !== "string") {
-    return invalidParamsError(index, `argument must be a hex string`);
-  }
-
-  if (!hexString.startsWith("0x")) {
-    return invalidParamsError(index, `hex string without 0x prefix`);
-  }
-
-  if (!validateHexString(hexString)) {
-    return invalidParamsError(index, `invalid hex string`);
+  const err = verifyHexNumber(blockParameter, index);
+  if (err) {
+    return padErrorContext(err, "blockParameter block number");
   }
 
   return undefined;
 }
 
-function verifyFilterTopic(topic: any, index: number): any {
+export function verifyOptEthCallObject(
+  callObj: any,
+  index: number
+): InvalidParamsError | undefined {
+  if (typeof callObj !== "object") {
+    return invalidParamsError(index, `argument must be an object`);
+  }
+
+  const from = callObj.from;
+  const to = callObj.to;
+  const gas = callObj.gas;
+  const gasLimit = callObj.gasLimit;
+  const value = callObj.value;
+  const data = callObj.data;
+
+  // validate `to`
+  if (to != null) {
+    const toErr = verifyAddress(to, index);
+    if (toErr) {
+      return padErrorContext(toErr, "callObj to address");
+    }
+  }
+
+  // validate `from`
+  if (from != null) {
+    const fromErr = verifyAddress(from, index);
+    if (fromErr) {
+      return padErrorContext(fromErr, "callObj from address");
+    }
+  }
+
+  // validate `gas`
+  if (gas != null) {
+    const gasErr = verifyHexNumber(gas, index);
+    if (gasErr) {
+      return padErrorContext(gasErr, "callObj gas");
+    }
+  }
+
+  // validate `gasLimit`
+  if (gasLimit != null) {
+    const gasLimitErr = verifyHexNumber(gasLimit, index);
+    if (gasLimitErr) {
+      return padErrorContext(gasLimitErr, "callObj gasLimit");
+    }
+  }
+
+  // validate `value`
+  if (value != null) {
+    const valueErr = verifyHexNumber(value, index);
+    if (valueErr) {
+      return padErrorContext(valueErr, "callObj value");
+    }
+  }
+
+  // validate `data`
+  if (data != null) {
+    const dataErr = verifyHexString(data, index);
+    if (dataErr) {
+      return padErrorContext(dataErr, "callObj data");
+    }
+  }
+
+  return undefined;
+}
+
+export function verifyEthCallObject(
+  callObj: any,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyOptEthCallObject(callObj, index);
+  if (err) {
+    return padErrorContext(err, "eth_call");
+  }
+
+  // to is required
+  if (callObj.to == null) {
+    return invalidParamsError(index, `eth_call to address is required!`);
+  }
+
+  return undefined;
+}
+
+export function verifyEstimateGasCallObject(
+  callObj: any,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyOptEthCallObject(callObj, index);
+  if (err) {
+    return padErrorContext(err, "eth_estimateGas");
+  }
+
+  return undefined;
+}
+
+export function verifyStorageKey(
+  key: string,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyHexString(key, index);
+  if (err) {
+    return padErrorContext(err, "storageKey");
+  }
+  return undefined;
+}
+
+export function verifyFilterTopicString(
+  topic: any,
+  index: number
+): InvalidParamsError | undefined {
+  const err = verifyHexString(topic, index);
+  if (err) {
+    return padErrorContext(err, "topic string");
+  }
+
+  if (topic.substring(2).length !== 64) {
+    return invalidParamsError(
+      index,
+      `expect topic string has 32 bytes, but getting ${
+        topic.substring(2).length / 2
+      } bytes`
+    );
+  }
+
+  return undefined;
+}
+
+export function verifyFilterTopic(
+  topic: any,
+  index: number
+): InvalidParamsError | undefined {
   // topic type: export type FilterTopic = HexString | null | HexString[] (../src/cache/type.ts)
   if (!Array.isArray(topic)) {
-    if ((!validateHexString(topic) || topic.length !== 66) && topic !== null) {
-      return invalidParamsError(index, `invalid argument`);
-    }
+    return verifyFilterTopicString(topic, index);
   }
 
   if (Array.isArray(topic)) {
     for (const t of topic) {
-      if ((!validateHexString(t) || t.length !== 66) && t !== null) {
-        return invalidParamsError(index, `invalid argument`);
+      const err = verifyFilterTopicString(t, index);
+      if (err) {
+        return padErrorContext(err, "topicString[] array");
       }
     }
   }
@@ -435,10 +420,88 @@ function verifyFilterTopic(topic: any, index: number): any {
   return undefined;
 }
 
-function validateAddress(address: string): boolean {
-  return /^0x[0-9a-fA-F]+$/.test(address) && address.length === 42;
-}
+export function verifyNewFilterObj(
+  filterObj: any,
+  index: number
+): InvalidParamsError | undefined {
+  if (typeof filterObj !== "object") {
+    return invalidParamsError(index, `filter argument must be an object`);
+  }
 
+  const fromBlock = filterObj.fromBlock;
+  const toBlock = filterObj.toBlock;
+  const address = filterObj.address;
+  const topics = filterObj.topics;
+
+  // validate `fromBlock`
+  if (fromBlock != null) {
+    const fromBlockErr = verifyBlockParameter(fromBlock, index);
+    if (fromBlockErr) {
+      return padErrorContext(fromBlockErr, "filter fromBlock");
+    }
+  }
+
+  // validate `toBlock`
+  if (toBlock != null) {
+    const toBlockErr = verifyBlockParameter(toBlock, index);
+    if (toBlockErr) {
+      return padErrorContext(toBlockErr, "filter toBlock");
+    }
+  }
+
+  // validate `address`
+  if (address != null) {
+    if (Array.isArray(address)) {
+      for (const addr of address) {
+        const addressErr = verifyAddress(addr, index);
+        if (addressErr) {
+          return padErrorContext(addressErr, "filter address[] element");
+        }
+      }
+    } else {
+      const addressErr = verifyAddress(address, index);
+      if (addressErr) {
+        return padErrorContext(addressErr, "filter address");
+      }
+    }
+  }
+
+  // validate `topics`
+  if (topics != null) {
+    if (!Array.isArray(topics)) {
+      return invalidParamsError(index, `filter topics must be an array`);
+    }
+    for (const topic of topics) {
+      const topicErr = verifyFilterTopic(topic, index);
+      if (topicErr) {
+        return padErrorContext(topicErr, "filter topic[] Array");
+      }
+    }
+  }
+
+  return undefined;
+}
+//******* end of standalone verify function ********/
+
+// some utils function
 function invalidParamsError(index: number, message: string): any {
   return new InvalidParamsError(`invalid argument ${index}: ${message}`);
+}
+
+function padErrorContext(
+  err: InvalidParamsError,
+  context: string
+): InvalidParamsError {
+  const msgs = err.message.split(/(invalid argument .: )/);
+  // [ '', 'invalid argument <number>: ', 'message' ]
+  if (msgs.length !== 3) {
+    throw new Error(
+      `parse InvalidParamsError message failed: ${err.message}, ${msgs}`
+    );
+  }
+  const newMsg = `${msgs[1]}${context} -> ${msgs[2]}`;
+  return {
+    ...err,
+    ...{ message: newMsg },
+  } as InvalidParamsError;
 }

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -197,7 +197,7 @@ export function verifyAddress(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(address, index);
   if (err) {
-    return padErrorContext(err, "address");
+    return err.padErrorContext("address");
   }
 
   if (address.substring(2).length !== 40) {
@@ -218,7 +218,7 @@ export function verifyBlockHash(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(blockHash, index);
   if (err) {
-    return padErrorContext(err, "blockHash");
+    return err.padErrorContext("blockHash");
   }
 
   if (blockHash.substring(2).length !== 64) {
@@ -239,7 +239,7 @@ export function verifyTxHash(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(txHash, index);
   if (err) {
-    return padErrorContext(err, "txHash");
+    return err.padErrorContext("txHash");
   }
 
   if (txHash.substring(2).length !== 64) {
@@ -268,7 +268,7 @@ export function verifyBlockParameter(
 
   const err = verifyHexNumber(blockParameter, index);
   if (err) {
-    return padErrorContext(err, "blockParameter block number");
+    return err.padErrorContext("blockParameter block number");
   }
 
   return undefined;
@@ -293,7 +293,7 @@ export function verifyOptEthCallObject(
   if (to != null) {
     const toErr = verifyAddress(to, index);
     if (toErr) {
-      return padErrorContext(toErr, "callObj to address");
+      return toErr.padErrorContext("callObj to address");
     }
   }
 
@@ -301,7 +301,7 @@ export function verifyOptEthCallObject(
   if (from != null) {
     const fromErr = verifyAddress(from, index);
     if (fromErr) {
-      return padErrorContext(fromErr, "callObj from address");
+      return fromErr.padErrorContext("callObj from address");
     }
   }
 
@@ -309,7 +309,7 @@ export function verifyOptEthCallObject(
   if (gasPrice != null) {
     const gasErr = verifyHexNumber(gasPrice, index);
     if (gasErr) {
-      return padErrorContext(gasErr, "callObj gasPrice");
+      return gasErr.padErrorContext("callObj gasPrice");
     }
   }
 
@@ -317,7 +317,7 @@ export function verifyOptEthCallObject(
   if (gasLimit != null) {
     const gasLimitErr = verifyGasLimit(gasLimit, index);
     if (gasLimitErr) {
-      return padErrorContext(gasLimitErr, "callObj");
+      return gasLimitErr.padErrorContext("callObj");
     }
   }
 
@@ -325,7 +325,7 @@ export function verifyOptEthCallObject(
   if (value != null) {
     const valueErr = verifyHexNumber(value, index);
     if (valueErr) {
-      return padErrorContext(valueErr, "callObj value");
+      return valueErr.padErrorContext("callObj value");
     }
   }
 
@@ -333,7 +333,7 @@ export function verifyOptEthCallObject(
   if (data != null) {
     const dataErr = verifyHexString(data, index);
     if (dataErr) {
-      return padErrorContext(dataErr, "callObj data");
+      return dataErr.padErrorContext("callObj data");
     }
   }
 
@@ -346,7 +346,7 @@ export function verifyEthCallObject(
 ): InvalidParamsError | undefined {
   const err = verifyOptEthCallObject(callObj, index);
   if (err) {
-    return padErrorContext(err, "eth_call");
+    return err.padErrorContext("eth_call");
   }
 
   // to is required
@@ -363,7 +363,7 @@ export function verifyEstimateGasCallObject(
 ): InvalidParamsError | undefined {
   const err = verifyOptEthCallObject(callObj, index);
   if (err) {
-    return padErrorContext(err, "eth_estimateGas");
+    return err.padErrorContext("eth_estimateGas");
   }
 
   return undefined;
@@ -375,7 +375,7 @@ export function verifyStorageKey(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(key, index);
   if (err) {
-    return padErrorContext(err, "storageKey");
+    return err.padErrorContext("storageKey");
   }
   return undefined;
 }
@@ -386,7 +386,7 @@ export function verifyFilterTopicString(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(topic, index);
   if (err) {
-    return padErrorContext(err, "topic string");
+    return err.padErrorContext("topic string");
   }
 
   if (topic.substring(2).length !== 64) {
@@ -414,7 +414,7 @@ export function verifyFilterTopic(
     for (const t of topic) {
       const err = verifyFilterTopicString(t, index);
       if (err) {
-        return padErrorContext(err, "topicString[] array");
+        return err.padErrorContext("topicString[] array");
       }
     }
   }
@@ -439,7 +439,7 @@ export function verifyNewFilterObj(
   if (fromBlock != null) {
     const fromBlockErr = verifyBlockParameter(fromBlock, index);
     if (fromBlockErr) {
-      return padErrorContext(fromBlockErr, "filter fromBlock");
+      return fromBlockErr.padErrorContext("filter fromBlock");
     }
   }
 
@@ -447,7 +447,7 @@ export function verifyNewFilterObj(
   if (toBlock != null) {
     const toBlockErr = verifyBlockParameter(toBlock, index);
     if (toBlockErr) {
-      return padErrorContext(toBlockErr, "filter toBlock");
+      return toBlockErr.padErrorContext("filter toBlock");
     }
   }
 
@@ -457,13 +457,13 @@ export function verifyNewFilterObj(
       for (const addr of address) {
         const addressErr = verifyAddress(addr, index);
         if (addressErr) {
-          return padErrorContext(addressErr, "filter address[] Array");
+          return addressErr.padErrorContext("filter address[] Array");
         }
       }
     } else {
       const addressErr = verifyAddress(address, index);
       if (addressErr) {
-        return padErrorContext(addressErr, "filter address");
+        return addressErr.padErrorContext("filter address");
       }
     }
   }
@@ -476,7 +476,7 @@ export function verifyNewFilterObj(
     for (const topic of topics) {
       const topicErr = verifyFilterTopic(topic, index);
       if (topicErr) {
-        return padErrorContext(topicErr, "filter topic[] Array");
+        return topicErr.padErrorContext("filter topic[] Array");
       }
     }
   }
@@ -490,7 +490,7 @@ export function verifyGasLimit(
 ): InvalidParamsError | undefined {
   const gasLimitErr = verifyHexNumber(gasLimit, index);
   if (gasLimitErr) {
-    return padErrorContext(gasLimitErr, "gasLimit");
+    return gasLimitErr.padErrorContext("gasLimit");
   }
 
   if (BigInt(gasLimit) > BigInt(POLY_MAX_BLOCK_GAS_LIMIT)) {
@@ -506,22 +506,4 @@ export function verifyGasLimit(
 // some utils function
 function invalidParamsError(index: number, message: string) {
   return new InvalidParamsError(`invalid argument ${index}: ${message}`);
-}
-
-export function padErrorContext(
-  err: InvalidParamsError,
-  context: string
-): InvalidParamsError {
-  const msgs = err.message.split(/(invalid argument .: )/);
-  // [ '', 'invalid argument <number>: ', 'message' ]
-  if (msgs.length !== 3) {
-    throw new Error(
-      `parse InvalidParamsError message failed: ${err.message}, ${msgs}`
-    );
-  }
-  const newMsg = `${msgs[1]}${context} -> ${msgs[2]}`;
-  return {
-    ...err,
-    ...{ message: newMsg },
-  } as InvalidParamsError;
 }

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -455,7 +455,7 @@ export function verifyNewFilterObj(
       for (const addr of address) {
         const addressErr = verifyAddress(addr, index);
         if (addressErr) {
-          return padErrorContext(addressErr, "filter address[] element");
+          return padErrorContext(addressErr, "filter address[] Array");
         }
       }
     } else {

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -197,7 +197,7 @@ export function verifyAddress(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(address, index);
   if (err) {
-    return err.padErrorContext("address");
+    return err.padContext("address");
   }
 
   if (address.substring(2).length !== 40) {
@@ -218,7 +218,7 @@ export function verifyBlockHash(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(blockHash, index);
   if (err) {
-    return err.padErrorContext("blockHash");
+    return err.padContext("blockHash");
   }
 
   if (blockHash.substring(2).length !== 64) {
@@ -239,7 +239,7 @@ export function verifyTxHash(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(txHash, index);
   if (err) {
-    return err.padErrorContext("txHash");
+    return err.padContext("txHash");
   }
 
   if (txHash.substring(2).length !== 64) {
@@ -268,7 +268,7 @@ export function verifyBlockParameter(
 
   const err = verifyHexNumber(blockParameter, index);
   if (err) {
-    return err.padErrorContext("blockParameter block number");
+    return err.padContext("blockParameter block number");
   }
 
   return undefined;
@@ -293,7 +293,7 @@ export function verifyOptEthCallObject(
   if (to != null) {
     const toErr = verifyAddress(to, index);
     if (toErr) {
-      return toErr.padErrorContext("callObj to address");
+      return toErr.padContext("callObj to address");
     }
   }
 
@@ -301,7 +301,7 @@ export function verifyOptEthCallObject(
   if (from != null) {
     const fromErr = verifyAddress(from, index);
     if (fromErr) {
-      return fromErr.padErrorContext("callObj from address");
+      return fromErr.padContext("callObj from address");
     }
   }
 
@@ -309,7 +309,7 @@ export function verifyOptEthCallObject(
   if (gasPrice != null) {
     const gasErr = verifyHexNumber(gasPrice, index);
     if (gasErr) {
-      return gasErr.padErrorContext("callObj gasPrice");
+      return gasErr.padContext("callObj gasPrice");
     }
   }
 
@@ -317,7 +317,7 @@ export function verifyOptEthCallObject(
   if (gasLimit != null) {
     const gasLimitErr = verifyGasLimit(gasLimit, index);
     if (gasLimitErr) {
-      return gasLimitErr.padErrorContext("callObj");
+      return gasLimitErr.padContext("callObj");
     }
   }
 
@@ -325,7 +325,7 @@ export function verifyOptEthCallObject(
   if (value != null) {
     const valueErr = verifyHexNumber(value, index);
     if (valueErr) {
-      return valueErr.padErrorContext("callObj value");
+      return valueErr.padContext("callObj value");
     }
   }
 
@@ -333,7 +333,7 @@ export function verifyOptEthCallObject(
   if (data != null) {
     const dataErr = verifyHexString(data, index);
     if (dataErr) {
-      return dataErr.padErrorContext("callObj data");
+      return dataErr.padContext("callObj data");
     }
   }
 
@@ -346,7 +346,7 @@ export function verifyEthCallObject(
 ): InvalidParamsError | undefined {
   const err = verifyOptEthCallObject(callObj, index);
   if (err) {
-    return err.padErrorContext("eth_call");
+    return err.padContext("eth_call");
   }
 
   // to is required
@@ -363,7 +363,7 @@ export function verifyEstimateGasCallObject(
 ): InvalidParamsError | undefined {
   const err = verifyOptEthCallObject(callObj, index);
   if (err) {
-    return err.padErrorContext("eth_estimateGas");
+    return err.padContext("eth_estimateGas");
   }
 
   return undefined;
@@ -375,7 +375,7 @@ export function verifyStorageKey(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(key, index);
   if (err) {
-    return err.padErrorContext("storageKey");
+    return err.padContext("storageKey");
   }
   return undefined;
 }
@@ -386,7 +386,7 @@ export function verifyFilterTopicString(
 ): InvalidParamsError | undefined {
   const err = verifyHexString(topic, index);
   if (err) {
-    return err.padErrorContext("topic string");
+    return err.padContext("topic string");
   }
 
   if (topic.substring(2).length !== 64) {
@@ -414,7 +414,7 @@ export function verifyFilterTopic(
     for (const t of topic) {
       const err = verifyFilterTopicString(t, index);
       if (err) {
-        return err.padErrorContext("topicString[] array");
+        return err.padContext("topicString[] array");
       }
     }
   }
@@ -439,7 +439,7 @@ export function verifyNewFilterObj(
   if (fromBlock != null) {
     const fromBlockErr = verifyBlockParameter(fromBlock, index);
     if (fromBlockErr) {
-      return fromBlockErr.padErrorContext("filter fromBlock");
+      return fromBlockErr.padContext("filter fromBlock");
     }
   }
 
@@ -447,7 +447,7 @@ export function verifyNewFilterObj(
   if (toBlock != null) {
     const toBlockErr = verifyBlockParameter(toBlock, index);
     if (toBlockErr) {
-      return toBlockErr.padErrorContext("filter toBlock");
+      return toBlockErr.padContext("filter toBlock");
     }
   }
 
@@ -457,13 +457,13 @@ export function verifyNewFilterObj(
       for (const addr of address) {
         const addressErr = verifyAddress(addr, index);
         if (addressErr) {
-          return addressErr.padErrorContext("filter address[] Array");
+          return addressErr.padContext("filter address[] Array");
         }
       }
     } else {
       const addressErr = verifyAddress(address, index);
       if (addressErr) {
-        return addressErr.padErrorContext("filter address");
+        return addressErr.padContext("filter address");
       }
     }
   }
@@ -476,7 +476,7 @@ export function verifyNewFilterObj(
     for (const topic of topics) {
       const topicErr = verifyFilterTopic(topic, index);
       if (topicErr) {
-        return topicErr.padErrorContext("filter topic[] Array");
+        return topicErr.padContext("filter topic[] Array");
       }
     }
   }
@@ -490,7 +490,7 @@ export function verifyGasLimit(
 ): InvalidParamsError | undefined {
   const gasLimitErr = verifyHexNumber(gasLimit, index);
   if (gasLimitErr) {
-    return gasLimitErr.padErrorContext("gasLimit");
+    return gasLimitErr.padContext("gasLimit");
   }
 
   if (BigInt(gasLimit) > BigInt(POLY_MAX_BLOCK_GAS_LIMIT)) {

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -55,15 +55,15 @@ export const validators = {
    * @param {any[]} params parameters of method
    * @param {number} index index of parameter
    */
-  hexString(params: any[], index: number): any {
+  hexString(params: any[], index: number) {
     return verifyHexString(params[index], index);
   },
 
-  hexNumber(params: any[], index: number): any {
+  hexNumber(params: any[], index: number) {
     return verifyHexNumber(params[index], index);
   },
 
-  storageKey(params: any[], index: number): any {
+  storageKey(params: any[], index: number) {
     return verifyStorageKey(params[index], index);
   },
 
@@ -73,7 +73,7 @@ export const validators = {
    * @param index
    * @returns
    */
-  blockParameter(params: any[], index: number): any {
+  blockParameter(params: any[], index: number) {
     return verifyBlockParameter(params[index], index);
   },
 
@@ -82,7 +82,7 @@ export const validators = {
    * @param {any[]} params parameters of method
    * @param {number} index index of parameter
    */
-  blockHash(params: any[], index: number): any {
+  blockHash(params: any[], index: number) {
     return verifyBlockHash(params[index], index);
   },
 
@@ -91,7 +91,7 @@ export const validators = {
    * @param {any[]} params parameters of method
    * @param {number} index index of parameter
    */
-  txHash(params: any[], index: number): any {
+  txHash(params: any[], index: number) {
     return verifyTxHash(params[index], index);
   },
 
@@ -100,7 +100,7 @@ export const validators = {
    * @param {any[]} params parameters of method
    * @param {number} index index of parameter
    */
-  address(params: any[], index: number): any {
+  address(params: any[], index: number) {
     return verifyAddress(params[index], index);
   },
 
@@ -109,19 +109,19 @@ export const validators = {
    * @param {any[]} params parameters of method
    * @param {number} index index of parameter
    */
-  bool(params: any[], index: number): any {
+  bool(params: any[], index: number) {
     return verifyBoolean(params[index], index);
   },
 
-  ethCallParams(params: any[], index: number): any {
+  ethCallParams(params: any[], index: number) {
     return verifyEthCallObject(params[index], index);
   },
 
-  ethEstimateGasParams(params: any[], index: number): any {
+  ethEstimateGasParams(params: any[], index: number) {
     return verifyEstimateGasCallObject(params[index], index);
   },
 
-  newFilterParams(params: any[], index: number): any {
+  newFilterParams(params: any[], index: number) {
     return verifyNewFilterObj(params[index], index);
   },
 };


### PR DESCRIPTION
this pr refactor `validator.ts` file to:

- enable more clear structure / reduce some repeated code
- impl correct return type in function instead of any type
- pass context to give user a more clear params error message

---

```sh
{
    "jsonrpc": "2.0",
    "id": 73,
    "error": {
        "code": -32602,
        "message": "invalid argument 0: invalid argument"
    }
}                        
```
to

```sh
{
    "jsonrpc": "2.0",
    "id": 2,
    "error": {
        "code": -32602,
        "message": "invalid argument 0: filter topic[] Array -> expect topic string has 32 bytes, but getting 4 bytes"
    }
}
```

close #247 