### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,14 +7,24 @@ assignees: ''
 
 ---
 
-**Version**
+## **Version**
 - Godwoken v1 or v0?
-- The prebuild-image you are using or the commit-sha1
+- (Optional) Get the versions from `poly_version` RPC
+  <details>
+  <summary>command example</summary>
 
-**Describe the bug**
+  ```sh
+  curl https://godwoken-testnet-v1.ckbapp.dev -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc": "2.0", "method":"poly_version", "params": [], "id": 1}'
+  ```
+  </details>
+
+## **Describe the bug**
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Some actions on '....'
@@ -32,5 +42,5 @@ If applicable, add screenshots or logs to help explain your problem.
 some logs...
 ```
 
-**Additional context**
+## **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Version**
+- Godwoken v1 or v0?
+- The prebuild-image you are using or the commit-sha1
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Some actions on '....'
+3. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots or Logs**
+
+If applicable, add screenshots or logs to help explain your problem.
+
+```log
+some logs...
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[feat] "
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## New issue templates
- bug report
- feature request

---

- [x] It is difficult for reporters to get the prebuild-images versions. We should teach them how to get this information. For example, `kicker info` or use `gw_get_node_info` RPC.