### PR TITLE
Build in return data

### DIFF
--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -98,10 +98,6 @@ function parseReturnData(returnData: HexString): string {
     return "";
   }
 
-  if (returnData.length === 10) {
-    return "reverted with custom error";
-  }
-
   const abi = abiCoder as unknown as AbiCoder;
 
   const funcSig = returnData.slice(0, 10);

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -7,6 +7,7 @@ import { ErrorTransactionReceipt } from "../db/types";
 import { RpcError } from "./error";
 import { GW_RPC_REQUEST_ERROR } from "./error-code";
 import { LogItem, PolyjuiceSystemLog } from "./types";
+import { HexNumber, HexString } from "@ckb-lumos/base";
 
 export const evmcCodeTypeMapping: {
   [key: string]: string;
@@ -46,6 +47,77 @@ const gwErrorMapping: { [key: string]: { type: string; message: string } } = {
     message: "sender doesn't have enough funds to send tx",
   },
 };
+
+interface RevertErrorMapping {
+  [key: string]: {
+    message: (args: any[]) => string;
+    argTypes: string[];
+  };
+}
+
+// https://docs.soliditylang.org/en/v0.8.13/control-structures.html#panic-via-assert-and-error-via-require
+const revertErrorMapping: RevertErrorMapping = {
+  // Panic(uint256)
+  "0x4e487b71": {
+    message: (args: any[]) => {
+      const revertReason: HexNumber = "0x" + BigInt(args[0]).toString(16);
+      const msg = panicCodeToReason[revertReason];
+      if (msg != null) {
+        return `reverted with panic code ${revertReason} (${msg})`;
+      }
+      return `Panic(${revertReason})`;
+    },
+    argTypes: ["uint256"],
+  },
+  // Error(string)
+  "0x08c379a0": {
+    message: (args: any[]) => `Error(${args[0]})`,
+    argTypes: ["string"],
+  },
+};
+
+// From https://github.com/NomicFoundation/hardhat/blob/ef14cb35114b3e6b28ed697fe74049c38695afb3/packages/hardhat-core/src/internal/hardhat-network/stack-traces/panic-errors.ts#L13-L34
+const panicCodeToReason: { [key: string]: string } = {
+  "0x1": "Assertion error",
+  "0x11":
+    "Arithmetic operation underflowed or overflowed outside of an unchecked block",
+  "0x12": "Division or modulo division by zero",
+  "0x21":
+    "Tried to convert a value into an enum, but the value was too big or negative",
+  "0x22": "Incorrectly encoded storage byte array",
+  "0x31": ".pop() was called on an empty array",
+  "0x32": "Array accessed at an out-of-bounds or negative index",
+  "0x41":
+    "Too much memory was allocated, or an array was created that is too large",
+  "0x51": "Called a zero-initialized variable of internal function type",
+};
+
+function parseReturnData(returnData: HexString): string {
+  if (returnData.length < 10) {
+    return "";
+  }
+
+  const abi = abiCoder as unknown as AbiCoder;
+
+  const funcSig = returnData.slice(0, 10);
+  const revertInfo = revertErrorMapping[funcSig];
+
+  if (revertInfo != null) {
+    const encodedArgs = returnData.slice(10);
+    const parsedArgs = abi.decodeParameters(revertInfo.argTypes, encodedArgs);
+    const args = new Array(revertInfo.argTypes.length)
+      .fill(0)
+      .map((_, i) => parsedArgs[i]);
+    return revertInfo.message(args);
+  }
+
+  const reason = abi.decodeParameter(
+    "string",
+    returnData.slice(10)
+  ) as unknown as string;
+
+  return reason;
+}
 
 function parseGwErrorMapping(message: string): GwErrorItem | undefined {
   if (!message.startsWith(gwErrorPrefix)) {
@@ -104,15 +176,8 @@ export function parseGwError(error: any): GwErrorDetail {
       polyjuiceSystemLog = parsePolyjuiceSystemLog(err.data.last_log);
     }
 
-    const return_data = err.data.return_data;
-    let statusReason = "";
-    if (return_data !== "0x") {
-      const abi = abiCoder as unknown as AbiCoder;
-      statusReason = abi.decodeParameter(
-        "string",
-        return_data.substring(10)
-      ) as unknown as string;
-    }
+    const returnData = err.data.return_data;
+    const statusReason: string = parseReturnData(returnData);
 
     return {
       code: err.code,
@@ -151,16 +216,9 @@ export function parseGwRpcError(error: any): void {
     const last_log: LogItem | undefined = err.data?.last_log;
     if (last_log != null) {
       const polyjuiceSystemLog = parsePolyjuiceSystemLog(err.data.last_log);
-      const return_data = err.data.return_data;
+      const returnData = err.data.return_data;
 
-      let statusReason = "";
-      if (return_data !== "0x") {
-        const abi = abiCoder as unknown as AbiCoder;
-        statusReason = abi.decodeParameter(
-          "string",
-          return_data.substring(10)
-        ) as unknown as string;
-      }
+      const statusReason: string = parseReturnData(returnData);
 
       const failedReason: FailedReason = {
         status_code: "0x" + polyjuiceSystemLog.statusCode.toString(16),


### PR DESCRIPTION
Update revert messages

For `assert(false)`, it will cause `Panic(0x1)`, returns error message: 
```
revert: reverted with panic code 0x1 (Assertion error)
```

For `require("ReentrancyAttack: failed call")` it will case `Error(string)` returns error message
```
revert: Error(ReentrancyAttack: failed call)
```

More info for `Panic(uint256)` and `Error(string)` build-in error: [solidity doc](https://docs.soliditylang.org/en/v0.8.13/control-structures.html#panic-via-assert-and-error-via-require)

For custom error like 
```solidity
    error Empty();

    function testEmpty() public view returns(bool){
        revert Empty();
        return true;
    }
```

It will return

```
revert: reverted with custom error
```

