### PR TITLE
fix: allow jsonRpc params to be null

### DIFF
--- a/packages/api-server/src/methods/index.ts
+++ b/packages/api-server/src/methods/index.ts
@@ -31,7 +31,10 @@ function getMethods(argsList: ModConstructorArgs = {}) {
       .filter((methodName: string) => methodName !== "constructor")
       .forEach((methodName: string) => {
         const concatedMethodName = `${modName.toLowerCase()}_${methodName}`;
-        methods[concatedMethodName] = async (args: any[], cb: Callback) => {
+        methods[concatedMethodName] = async (
+          args: any[] | undefined,
+          cb: Callback
+        ) => {
           try {
             const result = await mod[methodName].bind(mod)(args);
             return cb(null, result);

--- a/packages/api-server/src/middlewares/jayson.ts
+++ b/packages/api-server/src/middlewares/jayson.ts
@@ -11,6 +11,12 @@ export const jaysonMiddleware = (
   res: Response,
   next: NextFunction
 ) => {
+  // we use jayson, and {params: null} will be treated as illegal while undefined will not.
+  // because this line of code https://github.com/tedeh/jayson/blob/master/lib/utils.js#L331
+  if (req.body && req.body.params === null) {
+    req.body.params = undefined;
+  }
+
   if (req.url.endsWith("/eth-wallet")) {
     const middleware =
       ethWalletServer.middleware() as createServer.NextHandleFunction;


### PR DESCRIPTION
close #313 

```sh
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": null
}
```
result

```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0x1b4b"
}
```