### PR TITLE
refactor: replace missing process.env with envConfig/gwConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ LOG_LEVEL=<optional, allowed value: `debug` / `info` / `warn` / `error`, default
 LOG_FORMAT=<optional, allowed value: `json`>
 MAX_SOCKETS=<optional, max number of httpAgent sockets per host for web3 connecting to godwoken, default to 10>
 WEB3_LOG_REQUEST_BODY=<optional, boolean, if true, will log request method / body, default to false>
-PORT=<optional, the api-server running port, default to 3000>
+PORT=<optional, the api-server running port, default to 8024>
 EOF
 
 $ yarn

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ ENABLE_CACHE_ETH_CALL=<optional, enable eth_call cache, default to false>
 LOG_LEVEL=<optional, allowed value: `debug` / `info` / `warn` / `error`, default to `debug` in development, and default to `info` in production>
 LOG_FORMAT=<optional, allowed value: `json`>
 MAX_SOCKETS=<optional, max number of httpAgent sockets per host for web3 connecting to godwoken, default to 10>
+WEB3_LOG_REQUEST_BODY=<optional, boolean, if true, will log request method / body, default to false>
+PORT=<optional, the api-server running port, default to 3000>
 EOF
 
 $ yarn

--- a/packages/api-server/src/app/app.ts
+++ b/packages/api-server/src/app/app.ts
@@ -70,7 +70,7 @@ app.use(
     }
 
     // log request method / body
-    if (process.env.WEB3_LOG_REQUEST_BODY) {
+    if (envConfig.logRequestBody) {
       logger.debug("request.body:", req.body);
     }
 

--- a/packages/api-server/src/app/www.ts
+++ b/packages/api-server/src/app/www.ts
@@ -8,5 +8,5 @@ import { envConfig } from "../base/env-config";
 /**
  * Get port from environment and store in Express.
  */
-const port: number = +(envConfig.port || "3000");
+const port: number = +(envConfig.port || "8024");
 startServer(port);

--- a/packages/api-server/src/app/www.ts
+++ b/packages/api-server/src/app/www.ts
@@ -3,9 +3,10 @@
  */
 
 import { startServer } from "./app";
+import { envConfig } from "../base/env-config";
 
 /**
  * Get port from environment and store in Express.
  */
-const port: number = +(process.env.PORT || "3000");
+const port: number = +(envConfig.port || "3000");
 startServer(port);

--- a/packages/api-server/src/base/env-config.ts
+++ b/packages/api-server/src/base/env-config.ts
@@ -18,6 +18,8 @@ export const envConfig = {
   enableCacheEthCall: getOptional("ENABLE_CACHE_ETH_CALL"),
   logLevel: getOptional("LOG_LEVEL"),
   logFormat: getOptional("LOG_FORMAT"),
+  logRequestBody: getOptional("WEB3_LOG_REQUEST_BODY"),
+  port: getOptional("PORT"),
 };
 
 function getRequired(name: string): string {

--- a/packages/api-server/src/methods/index.ts
+++ b/packages/api-server/src/methods/index.ts
@@ -3,6 +3,7 @@ import { Callback } from "./types";
 import * as Sentry from "@sentry/node";
 import { INVALID_PARAMS } from "./error-code";
 import { RpcError } from "./error";
+import { envConfig } from "../base/env-config";
 
 /**
  * get all methods. e.g., getBlockByNumber in eth module
@@ -36,7 +37,7 @@ function getMethods(argsList: ModConstructorArgs = {}) {
             const result = await mod[methodName].bind(mod)(args);
             return cb(null, result);
           } catch (err: any) {
-            if (process.env.SENTRY_DNS && err.code !== INVALID_PARAMS) {
+            if (envConfig.sentryDns && err.code !== INVALID_PARAMS) {
               Sentry.captureException(err, {
                 extra: { method: concatedMethodName, params: args },
               });

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -1307,7 +1307,7 @@ function buildPolyjuiceArgs(
     "L".charCodeAt(0),
     "Y".charCodeAt(0),
   ]);
-  const callKind = toId === +(process.env.CREATOR_ACCOUNT_ID as string) ? 3 : 0;
+  const callKind = toId === +gwConfig.accounts.polyjuiceCreator.id ? 3 : 0;
   const gasLimitBuf = Buffer.alloc(8);
   gasLimitBuf.writeBigUInt64LE(gas);
   const gasPriceBuf = Buffer.alloc(16);

--- a/packages/api-server/src/ws/wss.ts
+++ b/packages/api-server/src/ws/wss.ts
@@ -1,3 +1,4 @@
+import { envConfig } from "../base/env-config";
 import { logger } from "../base/logger";
 
 export function middleware(ws: any) {
@@ -10,7 +11,7 @@ export function middleware(ws: any) {
 
       if (Array.isArray(obj)) {
         // log request
-        if (process.env.WEB3_LOG_REQUEST_BODY) {
+        if (envConfig.logRequestBody) {
           logger.info("websocket request.body:", obj);
         } else {
           logger.info(
@@ -27,7 +28,7 @@ export function middleware(ws: any) {
       }
 
       // log request
-      if (process.env.WEB3_LOG_REQUEST_BODY) {
+      if (envConfig.logRequestBody) {
         logger.info("websocket request.body:", obj);
       } else {
         logger.info("websocket request.method:", obj.method);

--- a/packages/godwoken/src/rpc.ts
+++ b/packages/godwoken/src/rpc.ts
@@ -2,6 +2,7 @@ import http from "http";
 import https from "https";
 import { RPC as Rpc } from "@ckb-lumos/toolkit";
 
+// don't import from envConfig
 const maxSockets: number = process.env.MAX_SOCKETS
   ? +process.env.MAX_SOCKETS
   : 10;


### PR DESCRIPTION
we have some missing config still using `process.env.` instead of `envConfig` or `gwConfig`. this pr refactor such code.