### PR TITLE
feat: reuse simplified godwoken-test workflow

### DIFF
--- a/.github/workflows/godwoken-tests.yml
+++ b/.github/workflows/godwoken-tests.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   godwoken-tests:
-    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
+    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@simplify-workflow
     with:
-      web3_ref: "${{ github.sha }}"
-      kicker_ref: "refs/pull/253/head"
+      extra_github_env: |
+        MANUAL_BUILD_WEB3=true
+        MANUAL_BUILD_WEB3_INDEXER=true
+        WEB3_GIT_URL=https://github.com/${{ github.repository }}
+        WEB3_GIT_CHECKOUT=${{ github.ref }}


### PR DESCRIPTION
With this update, we can create PR from fork repos now.

The target godwoken-tests workflow: https://github.com/nervosnetwork/godwoken-tests/blob/simplify-workflow/.github/workflows/reusable-integration-test-v1.yml


Test run example: https://github.com/keroro520/godwoken-web3/runs/6651154508?check_suite_focus=true