### PR TITLE
fix: topic param can be null

### DIFF
--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -403,15 +403,15 @@ export function verifyFilterTopic(
 ): InvalidParamsError | undefined {
   // topic type: export type FilterTopic = HexString | null | HexString[] (../src/cache/type.ts)
   if (!Array.isArray(topic)) {
-    return verifyFilterTopicString(topic, index);
+    return topic == null ? undefined : verifyFilterTopicString(topic, index);
   }
 
-  if (Array.isArray(topic)) {
-    for (const t of topic) {
-      const err = verifyFilterTopicString(t, index);
-      if (err) {
-        return err.padContext("topicString[] array");
-      }
+  for (const t of topic) {
+    if (t == null) continue;
+
+    const err = verifyFilterTopicString(t, index);
+    if (err) {
+      return err.padContext("topicString[] array");
     }
   }
 


### PR DESCRIPTION
```sh
{
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params": [
        {

            "topics": [null, "0xFb2C72d3ffe10Ef7c9960272859a23D24db9e04A272859a23D24db9e04A27285", null]
        }
    ],
    "id": 1
}
```

---

before

```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32602,
        "message": "invalid argument 0: filter topic[] Array -> topic string -> hexString argument must be a string type"
    }
}
```

after

```sh
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0x7f70ca2221f1bf40195e28b1b8e4ab25"
}
```