### PR TITLE
perf: improve `eth_getLogs` performance

### DIFF
--- a/packages/api-server/src/db/helpers.ts
+++ b/packages/api-server/src/db/helpers.ts
@@ -99,6 +99,7 @@ export function formatLog(log: DBLog): Log {
     block_number: BigInt(log.block_number),
     log_index: +log.log_index,
     transaction_hash: bufferToHex(log.transaction_hash),
+    eth_tx_hash: log.eth_tx_hash ? bufferToHex(log.eth_tx_hash!) : undefined,
     block_hash: bufferToHex(log.block_hash),
     address: bufferToHex(log.address),
     data: bufferToHex(log.data),

--- a/packages/api-server/src/db/helpers.ts
+++ b/packages/api-server/src/db/helpers.ts
@@ -99,7 +99,7 @@ export function formatLog(log: DBLog): Log {
     block_number: BigInt(log.block_number),
     log_index: +log.log_index,
     transaction_hash: bufferToHex(log.transaction_hash),
-    eth_tx_hash: log.eth_tx_hash ? bufferToHex(log.eth_tx_hash!) : undefined,
+    eth_tx_hash: log.eth_tx_hash ? bufferToHex(log.eth_tx_hash) : undefined,
     block_hash: bufferToHex(log.block_hash),
     address: bufferToHex(log.address),
     data: bufferToHex(log.data),
@@ -327,7 +327,7 @@ export function buildQueryLogTopics(
   topics: FilterTopic[]
 ) {
   if (topics.length !== 0) {
-    queryBuilder.whereRaw(`array_length(topics, 1) >= ${topics.length}`);
+    queryBuilder.whereRaw(`array_length(topics, 1) >= ?`, [topics.length]);
   }
 
   topics.forEach((topic, index) => {

--- a/packages/api-server/src/db/query.ts
+++ b/packages/api-server/src/db/query.ts
@@ -313,7 +313,7 @@ export class Query {
       .where("id", ">", queryLastPollId.toString(10))
       .orderBy("id", "asc")
       .offset(queryOffset)
-      .limit(MAX_QUERY_NUMBER);
+      .limit(MAX_QUERY_NUMBER + 1);
     return logs.map((log) => formatLog(log));
   }
 

--- a/packages/api-server/src/db/query.ts
+++ b/packages/api-server/src/db/query.ts
@@ -23,7 +23,10 @@ import {
   bufferToHex,
   hexToBuffer,
   getDatabaseRateLimitingConfiguration,
+  buildQueryLogTopics,
+  universalizeAddress,
 } from "./helpers";
+import { FilterTopic } from "../cache/types";
 
 const poolMax = envConfig.pgPoolMax || 20;
 const GLOBAL_KNEX = Knex({
@@ -299,7 +302,8 @@ export class Query {
   private async queryLogsByBlockRange(
     fromBlock: HexNumber,
     toBlock: HexNumber,
-    address?: HexString | HexString[],
+    queryAddresses: HexString[],
+    queryTopics: FilterTopic[],
     lastPollId?: bigint,
     offset?: number
   ): Promise<Log[]> {
@@ -307,7 +311,8 @@ export class Query {
     const queryLastPollId = lastPollId || -1;
     const queryOffset = offset || 0;
     let logs: DBLog[] = await this.knex<DBLog>("logs")
-      .modify(buildQueryLogAddress, address)
+      .modify(buildQueryLogAddress, queryAddresses)
+      .modify(buildQueryLogTopics, queryTopics)
       .where("block_number", ">=", fromBlock)
       .where("block_number", "<=", toBlock)
       .where("id", ">", queryLastPollId.toString(10))
@@ -323,13 +328,13 @@ export class Query {
     toBlock?: bigint,
     offset?: number
   ): Promise<Log[]> {
-    const address = normalizeLogQueryAddress(option.address);
-    const topics = option.topics || [];
+    const queryTopics: FilterTopic[] = option.topics || [];
+    const queryAddresses: HexString[] = universalizeAddress(option.address);
 
     if (typeof blockHashOrFromBlock === "string" && toBlock == null) {
       const logs = await this.queryLogsByBlockHash(
         blockHashOrFromBlock,
-        address,
+        queryAddresses,
         undefined,
         offset
       );
@@ -338,14 +343,15 @@ export class Query {
         throw new Error(QUERY_OFFSET_REACHED_END);
       }
 
-      return filterLogsByTopics(logs, topics);
+      return filterLogsByTopics(logs, queryTopics);
     }
 
     if (typeof blockHashOrFromBlock === "bigint" && toBlock != null) {
       const logs = await this.queryLogsByBlockRange(
         blockHashOrFromBlock.toString(),
         toBlock.toString(),
-        address,
+        queryAddresses,
+        queryTopics,
         undefined,
         offset
       );
@@ -354,7 +360,7 @@ export class Query {
         throw new Error(QUERY_OFFSET_REACHED_END);
       }
 
-      return filterLogsByTopics(logs, topics);
+      return logs;
     }
 
     throw new Error("invalid params!");
@@ -386,10 +392,13 @@ export class Query {
     }
 
     if (typeof blockHashOrFromBlock === "bigint" && toBlock != null) {
+      const queryTopics: FilterTopic[] = option.topics || [];
+      const queryAddresses: HexString[] = universalizeAddress(option.address);
       const logs = await this.queryLogsByBlockRange(
         blockHashOrFromBlock.toString(),
         toBlock.toString(),
-        address,
+        queryAddresses,
+        queryTopics,
         lastPollId,
         offset
       );
@@ -398,7 +407,7 @@ export class Query {
         throw new Error(QUERY_OFFSET_REACHED_END);
       }
 
-      return filterLogsByTopics(logs, topics);
+      return logs;
     }
 
     throw new Error("invalid params!");

--- a/packages/api-server/src/db/types.ts
+++ b/packages/api-server/src/db/types.ts
@@ -92,7 +92,9 @@ export interface Transaction {
 export interface DBLog {
   id: string;
   transaction_id: string;
+  // TODO don't allow undefined
   transaction_hash: Buffer;
+  eth_tx_hash?: Buffer;
   transaction_index: number;
   block_number: string;
   block_hash: Buffer;
@@ -106,6 +108,7 @@ export interface Log {
   id: bigint;
   transaction_id: bigint;
   transaction_hash: Hash;
+  eth_tx_hash?: Hash;
   transaction_index: number;
   block_number: bigint;
   block_hash: Hash;

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -1035,6 +1035,7 @@ export class Eth {
     return await Promise.all(
       logs.map(async (log) => {
         const ethTxHash =
+          log.eth_tx_hash ||
           (await this.gwTxHashToEthTxHash(log.transaction_hash)) ||
           ZERO_TX_HASH;
         return toApiLog(log, ethTxHash);
@@ -1066,6 +1067,7 @@ export class Eth {
         return await Promise.all(
           logs.map(async (log) => {
             const ethTxHash =
+              log.eth_tx_hash ||
               (await this.gwTxHashToEthTxHash(log.transaction_hash)) ||
               ZERO_TX_HASH;
             return toApiLog(log, ethTxHash);
@@ -1088,6 +1090,7 @@ export class Eth {
       return await Promise.all(
         logs.map(async (log) => {
           const ethTxHash =
+            log.eth_tx_hash ||
             (await this.gwTxHashToEthTxHash(log.transaction_hash)) ||
             ZERO_TX_HASH;
           return toApiLog(log, ethTxHash);


### PR DESCRIPTION
Resolve https://github.com/nervosnetwork/godwoken-web3/issues/413

This PR aims to improve `eth_getLogs` performance and includes several optimizations. I suggest that reviewers review commit by commit:

1. commit ef75fc7ac5e0a01b4f72aec8229f3c0ae953eb04 perf: avoid redundant queries by increasing the limit by 1
    
    We consider a query to consume too much resource if it returns more results than
    $MAX_QUERY_NUMBER results, and respond with an error instead of the queried
    results. `limit(MAX_QUERY_NUMBER + 1)` only acquires needed results and meanwhile
    informs us know whether the queried results are over-sized.

2. commit 2ce32724cc9751a82bb2d597431c7f81173ac851 perf: add "topics" filter when querying logs from database
    
    Filtering logs by topics outside the database means we have to iterate the
    database multiple times to get a sufficient number of results, which is
    inefficient. By filtering topics using SQL, we can avoid iterating the database
    multiple times, such like:
    
    ```sql
    ...
        AND array_length(topics) >= 2
        AND topics[1] = '\x11..11'
        AND topics[2] IN ['\x22..22', '\x33.33']
    ```

3. commit d91a0692c7a1b7815a420c3b7522739b951add65 perf: improve efficency of indexing "logs"
    
    In this SQL, there is no `ORDER BY id` as combining `ORDER BY` and `LIMIT`
    consumes too much time when the results are large. Instead, logs are sorted
    outside the database:
    - When the number of query results exceeds $MAX_QUERY_NUMBER, an error is
    returned.
    - When the queried results are less than or equal to `$MAX_QUERY_NUMBER`,
    sorting takes only a short time

4. commit 178464eb08574c8961738e43ce0f8231515f9bd6 perf: acquire logs.eth_tx_hash using SQL JOIN
    
    The "logs" table does not contain the "eth_tx_hash" column. To obtain the logs'
    eth_tx_hash, we must query the "transactions" table.
    With SQL `JOIN`, we can easily obtain the log's eth_tx_hash.

----

### Local Benchmark

<details>
  <summary>The database has `437856` matched logs:</summary>
  <pre>
```
lumos=# select count(*) from logs where array_length(topics, 1) >= 1 and topics[1] = '\xe304654f140653267f4d09df4968c896d7d6fd0b8e23c45f1db26a86cf930001';
 count
--------
 437856
```</pre>
</details>

----

**ab.concurrency = 1** : `ab -p post.json -T application/json -c 1 -n 100  "http://127.0.0.1:8024/"`

| git.ref                  | ab.percentage | time(ms) |
| ------------------------ | ------------- | -------- |
| main 7c1f27d             | 50%           | 8312     |
| main 7c1f27d             | 90%           | 8863     |
| main 7c1f27d             | 95%           | 8967     |
| main 7c1f27d             | 100%          | 9576     |
| perf-eth_getLogs ad13f92 | 50%           | 285      |
| perf-eth_getLogs ad13f92 | 90%           | 314      |
| perf-eth_getLogs ad13f92 | 95%           | 322      |
| perf-eth_getLogs ad13f92 | 100%          | 346      |



**ab.concurrency = 20** : `ab -p post.json -T application/json -c 20 -n 100  "http://127.0.0.1:8024/"`

| git.ref                  | ab.percentage | time(ms) |
| ------------------------ | ------------- | -------- |
| main 7c1f27d             | 50%           | 92485    |
| main 7c1f27d             | 90%           | 105485   |
| main 7c1f27d             | 95%           | 112390   |
| main 7c1f27d             | 100%          | 131045   |
| perf-eth_getLogs ad13f92 | 50%           | 5542     |
| perf-eth_getLogs ad13f92 | 90%           | 6205     |
| perf-eth_getLogs ad13f92 | 95%           | 6337     |
| perf-eth_getLogs ad13f92 | 100%          | 7196     |


</details>