### PR TITLE
fix: Update revert error message and data

### DIFF
--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -71,7 +71,8 @@ const revertErrorMapping: RevertErrorMapping = {
   },
   // Error(string)
   "0x08c379a0": {
-    message: (args: any[]) => `Error(${args[0]})`,
+    message: (args: any[]) =>
+      `Error: VM Exception while processing transaction: reverted with reason string '${args[0]}'`,
     argTypes: ["string"],
   },
 };
@@ -284,7 +285,7 @@ export function parseGwRunResultError(err: any): RpcError {
   if (gwErr.statusReason != null) {
     failedReason.message = gwErr.statusReason;
   }
-  let errorData: any = undefined;
+  let errorData: any = {};
   if (Object.keys(failedReason).length !== 0) {
     errorData = { failed_reason: failedReason };
   }
@@ -297,5 +298,7 @@ export function parseGwRunResultError(err: any): RpcError {
       gwErr.statusReason
     }`;
   }
+  errorData.message = errorMessage;
+  errorData.data = (gwErr.data as any).return_data;
   return new RpcError(gwErr.code, errorMessage, errorData);
 }


### PR DESCRIPTION
`eth_call` RPC:

Godwoken Web3:

Update revert message format, for hardhat revert message need `data.message` and `data.data`，and `data.message` should in specific format.
For example: `Error: call revert exception; VM Exception while processing transaction: reverted with reason string "12341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341"`

```json
{
    "jsonrpc": "2.0",
    "id": 2,
    "error": {
        "code": -32099,
        "message": "revert: Error: VM Exception while processing transaction: reverted with reason string '12341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341'",
        "data": {
            "failed_reason": {
                "status_code": "0x2",
                "status_type": "REVERT",
                "message": "Error: VM Exception while processing transaction: reverted with reason string '12341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341'"
            },
            "message": "revert: Error: VM Exception while processing transaction: reverted with reason string '12341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341'",
            "data": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000aa313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343100000000000000000000000000000000000000000000"
        }
    }
}
```

Hardhat node:

```json
{
    "jsonrpc": "2.0",
    "id": 2,
    "error": {
        "code": -32603,
        "message": "Error: VM Exception while processing transaction: reverted with reason string '12341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341'",
        "data": {
            "message": "Error: VM Exception while processing transaction: reverted with reason string '12341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341123411234112341'",
            "data": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000aa313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343131323334313132333431313233343100000000000000000000000000000000000000000000"
        }
    }
}
```

