### PR TITLE
fix: correct parameter type of SQL query of eth_getBlockTransactionCountByHash

### DIFF
--- a/packages/api-server/src/db/query.ts
+++ b/packages/api-server/src/db/query.ts
@@ -239,18 +239,18 @@ export class Query {
   // undefined means not found
   async getBlockTransactionCountByHash(blockHash: Hash): Promise<number> {
     return await this.getBlockTransactionCount({
-      block_hash: blockHash,
+      block_hash: hexToBuffer(blockHash),
     });
   }
 
   async getBlockTransactionCountByNumber(blockNumber: bigint): Promise<number> {
     return await this.getBlockTransactionCount({
-      block_number: blockNumber,
+      block_number: blockNumber.toString(),
     });
   }
 
   private async getBlockTransactionCount(
-    params: Readonly<Partial<KnexType.MaybeRawRecord<Transaction>>>
+    params: Readonly<Partial<KnexType.MaybeRawRecord<DBTransaction>>>
   ): Promise<number> {
     const data = await this.knex<DBTransaction>("transactions")
       .where(params)


### PR DESCRIPTION
According to [the database schema](https://github.com/nervosnetwork/godwoken-web3/blob/7e689c50a7a8680717e0f8228f4c54f73da4038b/docs/schema_design.md#L23), `transaction.block_hash` is `bytea` but not text.