### PR TITLE
fix(ci): upgrade baseimage to 22.04

### DIFF
--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -8,7 +8,7 @@ RUN cargo install moleculec --version 0.7.2
 COPY . /godwoken-web3
 RUN cd /godwoken-web3 && rustup component add rustfmt && cargo build --release
 
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \


### PR DESCRIPTION
this ci is always failed... https://github.com/nervosnetwork/godwoken-web3/runs/7532460024?check_suite_focus=true

seems Ubuntu 21.04 (along with all flavors) is End-of-Life and thus unsupported on many sites? https://askubuntu.com/questions/1420130/cannot-do-apt-update-ip-address-not-found-no-release-file

Not sure if ubuntu 22.04 will change the behavior of web3-indexer via build