### PR TITLE
fix: declare StorageKey as HexNumber type

### DIFF
--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -131,7 +131,7 @@ export class Eth {
     ]);
     this.getStorageAt = middleware(this.getStorageAt.bind(this), 3, [
       validators.address,
-      validators.storageKey,
+      validators.hexNumber,
       validators.blockParameter,
     ]);
     this.getTransactionCount = middleware(

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -76,10 +76,6 @@ export const validators = {
     return verifyHexNumber(params[index], index);
   },
 
-  storageKey(params: any[], index: number) {
-    return verifyStorageKey(params[index], index);
-  },
-
   /**
    * Hex number | "latest" | "earliest" | "pending"
    * @param params
@@ -424,17 +420,6 @@ export function verifyEstimateGasCallObject(
     return err.padContext("eth_estimateGas");
   }
 
-  return undefined;
-}
-
-export function verifyStorageKey(
-  key: string,
-  index: number
-): InvalidParamsError | undefined {
-  const err = verifyHexString(key, index);
-  if (err) {
-    return err.padContext("storageKey");
-  }
   return undefined;
 }
 


### PR DESCRIPTION
Fix https://github.com/nervosnetwork/godwoken-web3/issues/507

Cause: [EIP-1474 declares the storage position as `Quantity` type](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#eth_getstorageat) but we declare it as `HexString`.
