### PR TITLE
refactor: handling godwoken error

### DIFF
--- a/packages/api-server/src/cache/data.ts
+++ b/packages/api-server/src/cache/data.ts
@@ -286,7 +286,8 @@ export function parseExecuteResult(res: string) {
   const executionResult = JSON.parse(res);
   if (executionResult?.status === PublishExecuteResultStatus.Success) {
     return (executionResult as PublishExecuteResult).data;
-  } else if (executionResult?.err != null) {
+  }
+  if (executionResult?.err != null) {
     handleGwError(executionResult.err);
   }
 

--- a/packages/api-server/src/cache/data.ts
+++ b/packages/api-server/src/cache/data.ts
@@ -1,3 +1,5 @@
+import { handleGwError } from "../methods/gw-error";
+
 require("newrelic");
 import { createClient } from "redis";
 import { envConfig } from "../base/env-config";
@@ -178,7 +180,7 @@ export class RedisDataCache {
             );
           }
           await releaseLock(lockValue);
-          throw new Error(error.message);
+          throw error;
         }
       }
 
@@ -199,7 +201,7 @@ export class RedisDataCache {
             `[${this.constructor.name}]: subscribe err:`,
             error.message
           );
-          throw new Error(error.message);
+          throw error;
         }
       }
 
@@ -281,12 +283,14 @@ export function errorResult(reason: string) {
 }
 
 export function parseExecuteResult(res: string) {
-  const jsonRes: PublishExecuteResult = JSON.parse(res);
-  if (jsonRes.status === PublishExecuteResultStatus.Success) {
-    return jsonRes.data!;
+  const executionResult = JSON.parse(res);
+  if (executionResult?.status === PublishExecuteResultStatus.Success) {
+    return (executionResult as PublishExecuteResult).data;
+  } else if (executionResult?.err != null) {
+    handleGwError(executionResult.err);
   }
 
-  throw new Error("[RedisSubscribeResult]" + jsonRes.err);
+  throw new Error("[RedisSubscribeResult] unrecognizable result: " + res);
 }
 
 const asyncSleep = async (ms = 0) => {

--- a/packages/api-server/src/methods/error-code.ts
+++ b/packages/api-server/src/methods/error-code.ts
@@ -16,6 +16,7 @@ export const RESOURCE_UNAVAILABLE = -32002;
 export const TRANSACTION_REJECTED = -32003;
 export const METHOD_NOT_SUPPORT = -32004;
 export const LIMIT_EXCEEDED = -32005;
+export const TRANSACTION_EXECUTION_ERROR = -32000;
 
 // Polyjuice Chain custom error
 // TODO - WEB3_ERROR is pretty generalize error

--- a/packages/api-server/src/methods/error.ts
+++ b/packages/api-server/src/methods/error.ts
@@ -22,7 +22,6 @@ export class RpcError extends Error implements JSONRPCError {
 
     this.code = code;
     this.data = data;
-    this.message = message;
   }
 }
 

--- a/packages/api-server/src/methods/error.ts
+++ b/packages/api-server/src/methods/error.ts
@@ -2,6 +2,7 @@ import { JSONRPCError } from "jayson";
 import { logger } from "../base/logger";
 import { HEADER_NOT_FOUND_ERR_MESSAGE } from "./constant";
 import {
+  TRANSACTION_EXECUTION_ERROR,
   HEADER_NOT_FOUND_ERROR,
   INTERNAL_ERROR,
   INVALID_PARAMS,
@@ -9,17 +10,29 @@ import {
   METHOD_NOT_SUPPORT,
   WEB3_ERROR,
 } from "./error-code";
+import { HexString } from "@ckb-lumos/base";
 
 export class RpcError extends Error implements JSONRPCError {
   code: number;
-  data?: object;
+  data?: any;
 
-  constructor(code: number, message: string, data?: object) {
+  constructor(code: number, message: string, data?: any) {
     super(message);
     this.name = "RpcError";
 
     this.code = code;
     this.data = data;
+    this.message = message;
+  }
+}
+
+export function isRpcError(err: any): err is RpcError {
+  return err.name === "RpcError";
+}
+
+export class TransactionExecutionError extends RpcError {
+  constructor(message: string, data?: HexString) {
+    super(TRANSACTION_EXECUTION_ERROR, message, data);
   }
 }
 

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -1,319 +1,202 @@
 // From https://github.com/ethereum/evmc/blob/v9.0.0/include/evmc/evmc.h#L212
 
 import abiCoder, { AbiCoder } from "web3-eth-abi";
-import { FailedReason } from "../base/types/api";
-import { COMPATIBLE_DOCS_URL } from "./constant";
-import { RpcError } from "./error";
-import { GW_RPC_REQUEST_ERROR } from "./error-code";
-import { LogItem, PolyjuiceSystemLog } from "./types";
+import { RpcError, TransactionExecutionError } from "./error";
 import { HexNumber, HexString } from "@ckb-lumos/base";
 import { logger } from "../base/logger";
+import { ErrorTxReceipt, isErrorTxReceipt } from "@godwoken-web3/godwoken";
+import { INTERNAL_ERROR } from "./error-code";
 
-const gwVmMaxCycleExitCode = "0xff";
-const gwVmMaxCycleErrMsg = "VM max cycle exceeded";
-// we use 3(OUT_OF_GAS in evmcCodeTypeMapping) as vm_max_cycle_exceeded status code
-const gwVmMaxCycleStatusCode = 3;
+const GODWOKEN_SERVER_ERROR_MESSAGE_PREFIX = "JSONRPCError: server error ";
 
-export const evmcCodeTypeMapping: {
-  [key: string]: string;
-} = {
-  "0": "SUCCESS",
-  "1": "FAILURE",
-  "2": "REVERT",
-  "3": "OUT_OF_GAS",
-  "4": "INVALID_INSTRUCTION",
-  "5": "UNDEFINED_INSTRUCTION",
-  "6": "STACK_OVERFLOW",
-  "7": "STACK_UNDERFLOW",
-  "8": "BAD_JUMP_DESTINATION",
-  "9": "INVALID_MEMORY_ACCESS",
-  "10": "CALL_DEPTH_EXCEEDED",
-  "11": "STATIC_MODE_VIOLATION",
-  "12": "PRECOMPILE_FAILURE",
-  "13": "CONTRACT_VALIDATION_FAILURE",
-  "14": "ARGUMENT_OUT_OF_RANGE",
-  "15": "WASM_UNREACHABLE_INSTRUCTION",
-  "16": "WASM_TRAP",
-  "17": "INSUFFICIENT_BALANCE",
-  "-1": "INTERNAL_ERROR",
-  "-2": "REJECTED",
-  "-3": "OUT_OF_MEMORY",
-};
+const REVERT_SELECTOR: string = "0x08c379a0";
+const PANIC_SELECTOR: string = "0x4e487b71";
 
-const gwErrorPrefix = "invalid exit code ";
-export interface GwErrorItem {
-  code: number;
-  type: string;
-  message: string;
-}
-const gwErrorMapping: { [key: string]: { type: string; message: string } } = {
-  "92": {
-    type: "SUDT_ERROR_INSUFFICIENT_BALANCE",
-    message: "sender doesn't have enough funds to send tx",
-  },
-};
-
-interface RevertErrorMapping {
-  [key: string]: {
-    message: (args: any[]) => string;
-    argTypes: string[];
-  };
+/**
+ * Determine whether the error is coming from Godwoken
+ */
+export function isGwError(err: any): boolean {
+  const message: string = err?.message || err;
+  return (
+    message != null &&
+    typeof message === "string" &&
+    message.startsWith(GODWOKEN_SERVER_ERROR_MESSAGE_PREFIX)
+  );
 }
 
-// https://docs.soliditylang.org/en/v0.8.13/control-structures.html#panic-via-assert-and-error-via-require
-const revertErrorMapping: RevertErrorMapping = {
-  // Panic(uint256)
-  "0x4e487b71": {
-    message: (args: any[]) => {
-      const revertReason: HexNumber = "0x" + BigInt(args[0]).toString(16);
-      const msg = panicCodeToReason[revertReason];
-      if (msg != null) {
-        return `reverted with panic code ${revertReason} (${msg})`;
-      }
-      return `Panic(${revertReason})`;
-    },
-    argTypes: ["uint256"],
-  },
-  // Error(string)
-  "0x08c379a0": {
-    message: (args: any[]) =>
-      `Error: VM Exception while processing transaction: reverted with reason string '${args[0]}'`,
-    argTypes: ["string"],
-  },
-};
-
-// From https://github.com/NomicFoundation/hardhat/blob/ef14cb35114b3e6b28ed697fe74049c38695afb3/packages/hardhat-core/src/internal/hardhat-network/stack-traces/panic-errors.ts#L13-L34
-const panicCodeToReason: { [key: string]: string } = {
-  "0x1": "Assertion error",
-  "0x11":
-    "Arithmetic operation underflowed or overflowed outside of an unchecked block",
-  "0x12": "Division or modulo division by zero",
-  "0x21":
-    "Tried to convert a value into an enum, but the value was too big or negative",
-  "0x22": "Incorrectly encoded storage byte array",
-  "0x31": ".pop() was called on an empty array",
-  "0x32": "Array accessed at an out-of-bounds or negative index",
-  "0x41":
-    "Too much memory was allocated, or an array was created that is too large",
-  "0x51": "Called a zero-initialized variable of internal function type",
-};
-
-function parseReturnData(returnData: HexString): string {
-  if (returnData.length < 10) {
-    return "";
+/**
+ * Parse the given Godwoken error, translate into RpcError and then throw it
+ *
+ * @param gwJsonrpcError
+ *
+ * @throws RpcError
+ */
+export function handleGwError(gwJsonrpcError: any) {
+  if (!isGwError(gwJsonrpcError)) {
+    throw gwJsonrpcError;
   }
 
-  const abi = abiCoder as unknown as AbiCoder;
+  const message: string = gwJsonrpcError?.message || gwJsonrpcError;
+  const err = JSON.parse(
+    message.slice(GODWOKEN_SERVER_ERROR_MESSAGE_PREFIX.length)
+  );
 
-  const funcSig = returnData.slice(0, 10);
-  const revertInfo = revertErrorMapping[funcSig];
-
-  if (revertInfo != null) {
-    const encodedArgs = returnData.slice(10);
-    const parsedArgs = abi.decodeParameters(revertInfo.argTypes, encodedArgs);
-    const args = new Array(revertInfo.argTypes.length)
-      .fill(0)
-      .map((_, i) => parsedArgs[i]);
-    return revertInfo.message(args);
-  }
-  let reason = "";
-  try {
-    reason = abi.decodeParameter(
-      "string",
-      returnData.slice(10)
-    ) as unknown as string;
-  } catch (e) {
-    logger.info(`Parse reason failed with return data: ${returnData}`);
-    reason = "reverted with custom error";
-  }
-
-  return reason;
-}
-
-function parseGwErrorMapping(message: string): GwErrorItem | undefined {
-  if (!message.startsWith(gwErrorPrefix)) {
-    return undefined;
-  }
-  const code = message.slice(gwErrorPrefix.length);
-
-  const item = gwErrorMapping[code];
-  if (item != null) {
-    return {
-      code: +code,
-      type: item.type,
-      message: item.message,
-    };
-  }
-
-  return undefined;
-}
-
-export interface GwErrorDetail {
-  code: number;
-  message: string;
-  data: object;
-  polyjuiceSystemLog?: PolyjuiceSystemLog;
-  statusCode?: number;
-  statusReason?: string;
-}
-
-export function parseGwError(error: any): GwErrorDetail {
-  const prefix = "JSONRPCError: server error ";
-  let message: string = error.message;
-  if (message.startsWith(prefix)) {
-    const jsonErr = message.slice(prefix.length);
-    const err = JSON.parse(jsonErr);
-
-    if (err.data == null) {
-      parseGwRpcError(error);
+  if (isTransactionErrorInvalidExitCode(err)) {
+    // Example:
+    // ```rust
+    // {
+    //     code: INVALID_REQUEST,
+    //     message: TransactionError::InvalidExitCode(run_result.exit_code).to_string(),
+    //     data: Some(Box::new(ErrorTxReceipt::from(receipt))),
+    // };
+    // ```
+    //
+    // For `TransactionError::InvalidExitCode`, the `data` field should always be `ErrorTxReceipt`
+    if (isErrorTxReceipt(err.data)) {
+      handleErrorTxReceipt(err.data as ErrorTxReceipt);
     }
-
-    const gwErrorItem = parseGwErrorMapping(err.message);
-    if (gwErrorItem != null) {
-      const failedReason: FailedReason = {
-        status_code: "0x" + gwErrorItem.code.toString(16),
-        status_type: gwErrorItem.type,
-        message: gwErrorItem.message,
-      };
-      const data = { failed_reason: failedReason };
-      const newMessage = `${failedReason.status_type.toLowerCase()}: ${
-        failedReason.message
-      }`;
-      throw new RpcError(err.code, newMessage, data);
-    }
-
-    let polyjuiceSystemLog: PolyjuiceSystemLog | undefined;
-    if (err.data.last_log) {
-      polyjuiceSystemLog = parsePolyjuiceSystemLog(err.data.last_log);
-    }
-
-    const returnData = err.data.return_data;
-
-    // when tx reach vm max cycles, evm status code is success
-    // but godwoken return err.data.exit_code = 0xff, we should handle such case
-    const statusReason: string =
-      err.data.exit_code === gwVmMaxCycleExitCode
-        ? gwVmMaxCycleErrMsg
-        : parseReturnData(returnData);
-    const statusCode =
-      err.data.exit_code === gwVmMaxCycleExitCode
-        ? gwVmMaxCycleStatusCode
-        : polyjuiceSystemLog?.statusCode;
-
-    return {
-      code: err.code,
-      message: err.message,
-      data: err.data,
-      polyjuiceSystemLog,
-      statusCode,
-      statusReason,
-    };
-  }
-
-  throw error;
-}
-
-export function parseGwRpcError(error: any): void {
-  const prefix = "JSONRPCError: server error ";
-  let message: string = error.message;
-  if (message.startsWith(prefix)) {
-    const jsonErr = message.slice(prefix.length);
-    const err = JSON.parse(jsonErr);
-
-    const gwErrorItem = parseGwErrorMapping(err.message);
-    if (gwErrorItem != null) {
-      const failedReason: FailedReason = {
-        status_code: "0x" + gwErrorItem.code.toString(16),
-        status_type: gwErrorItem.type,
-        message: gwErrorItem.message,
-      };
-      const data = { failed_reason: failedReason };
-      const newMessage = `${failedReason.status_type.toLowerCase()}: ${
-        failedReason.message
-      }`;
-      throw new RpcError(err.code, newMessage, data);
-    }
-
-    const last_log: LogItem | undefined = err.data?.last_log;
-    if (last_log != null) {
-      const polyjuiceSystemLog = parsePolyjuiceSystemLog(err.data.last_log);
-      const returnData = err.data.return_data;
-
-      const statusReason: string = parseReturnData(returnData);
-
-      const failedReason: FailedReason = {
-        status_code: "0x" + polyjuiceSystemLog.statusCode.toString(16),
-        status_type:
-          evmcCodeTypeMapping[polyjuiceSystemLog.statusCode.toString()],
-        message: statusReason,
-      };
-      const data = { failed_reason: failedReason };
-      const newMessage = `${failedReason.status_type.toLowerCase()}: ${
-        failedReason.message
-      }`;
-      throw new RpcError(err.code, newMessage, data);
-    }
-
-    // can't find backend by script hash error
-    if (err.message?.includes("can't find backend for script_hash")) {
-      throw new RpcError(
-        err.code,
-        `to address is not a valid contract. more info: ${COMPATIBLE_DOCS_URL}`
-      );
-    }
-
-    throw new RpcError(err.code, err.message);
-  }
-
-  // connection error
-  if (message.startsWith("request to")) {
+  } else if (message.startsWith("request to")) {
+    // Connection error
     throw new Error(message);
   }
 
-  throw new RpcError(GW_RPC_REQUEST_ERROR, error.message);
+  throw new RpcError(
+    err.code || INTERNAL_ERROR,
+    err.message || gwJsonrpcError.toString(),
+    err.data
+  );
 }
 
-export function parsePolyjuiceSystemLog(logItem: LogItem): PolyjuiceSystemLog {
-  let buf = Buffer.from(logItem.data.slice(2), "hex");
-  if (buf.length !== 8 + 8 + 16 + 4 + 4) {
-    throw new Error(`invalid system log raw data length: ${buf.length}`);
+/**
+ * Throw TransactionExecutionError transferred from ErrorTxReceipt
+ *
+ * @param errorTxReceipt
+ * @throws TransactionExecutionError
+ */
+export function handleErrorTxReceipt(errorTxReceipt: ErrorTxReceipt) {
+  const returnData = errorTxReceipt.return_data;
+  const message = parseReturnData(returnData);
+  if (errorTxReceipt.return_data.length > 2) {
+    throw new TransactionExecutionError(message, returnData);
+  } else {
+    throw new TransactionExecutionError(message);
   }
-  const gasUsed = buf.readBigUInt64LE(0);
-  const cumulativeGasUsed = buf.readBigUInt64LE(8);
-  const createdAddress = "0x" + buf.slice(16, 36).toString("hex");
-  const statusCode = buf.readUInt32LE(36);
-  return {
-    gasUsed: gasUsed,
-    cumulativeGasUsed: cumulativeGasUsed,
-    createdAddress: createdAddress,
-    statusCode: statusCode,
+}
+
+/**
+ * Resolves the abi-encoded panic reason or revert reason.
+ *
+ * @param {HexString} returnData The returned data in [ErrorTxReceipt](https://github.com/nervosnetwork/godwoken/blob/c4be58f30744aef83717e2a12d60fe4d50b165ab/crates/jsonrpc-types/src/godwoken.rs#L1310-L1317)
+ *
+ * @see {@link https://docs.soliditylang.org/en/v0.8.13/control-structures.html#panic-via-assert-and-error-via-require}
+ */
+export function parseReturnData(returnData: HexString): string {
+  if (returnData.slice(0, REVERT_SELECTOR.length) === REVERT_SELECTOR) {
+    return unpackRevert(returnData);
+  } else if (returnData.slice(0, PANIC_SELECTOR.length) === PANIC_SELECTOR) {
+    return unpackPanic(returnData);
+  } else {
+    return "execution reverted";
+  }
+}
+
+/**
+ * Resolves the abi-encoded revert reason. According to the solidity
+ * spec https://solidity.readthedocs.io/en/latest/control-structures.html#revert,
+ * the provided revert reason is abi-encoded as if it were a call to a function
+ * `Error(string)`. So it's a special tool for it.
+ *
+ * @param {HexString} returnData The returned data in [ErrorTxReceipt](https://github.com/nervosnetwork/godwoken/blob/c4be58f30744aef83717e2a12d60fe4d50b165ab/crates/jsonrpc-types/src/godwoken.rs#L1310-L1317)
+ *
+ * @return {(string)} The wrapped revert reason
+ *
+ * @see {@link https://github.com/ethereum/go-ethereum/blob/420b78659bef661a83c5c442121b13f13288c09f/accounts/abi/abi.go#L262-L279}
+ *
+ * @example
+ * // returns "execution reverted"
+ * Solidity `revert()`
+ *
+ * @example
+ * // returns "execution reverted"
+ * Solidity `revert(CustomError({reason: "reason"}))`
+ *
+ * @example
+ * // returns "execution reverted: "
+ * Solidity `revert("")`
+ *
+ * @example
+ * // returns "execution reverted: reason"
+ * Solidity `revert("reason")`
+ */
+export function unpackRevert(returnData: HexString): string {
+  if (returnData.slice(0, REVERT_SELECTOR.length) !== REVERT_SELECTOR) {
+    return "execution reverted";
+  }
+  if (returnData.length === REVERT_SELECTOR.length) {
+    return "execution reverted: ";
+  }
+
+  const abi = abiCoder as unknown as AbiCoder;
+  try {
+    const parsedArgs = abi.decodeParameters(
+      ["string"],
+      returnData.slice(REVERT_SELECTOR.length)
+    );
+    const reason = parsedArgs[0];
+    return `execution reverted: ${reason}`;
+  } catch (err: any) {
+    logger.error(
+      `fail to decode revert reason, error: ${err}, returnData: ${returnData}`
+    );
+    return "execution reverted";
+  }
+}
+
+/**
+ * Resolves the abi-encoded panicked reason.
+ *
+ * @see {@link https://docs.soliditylang.org/en/v0.8.13/control-structures.html#panic-via-assert-and-error-via-require}
+ */
+export function unpackPanic(returnData: HexString): string {
+  if (returnData.slice(0, PANIC_SELECTOR.length) !== PANIC_SELECTOR) {
+    return "execution reverted";
+  }
+
+  // From https://github.com/NomicFoundation/hardhat/blob/ef14cb35114b3e6b28ed697fe74049c38695afb3/packages/hardhat-core/src/internal/hardhat-network/stack-traces/panic-errors.ts#L13-L34
+  const panicCodeToReason: { [key: string]: string } = {
+    "0x1": "Assertion error",
+    "0x11":
+      "Arithmetic operation underflowed or overflowed outside of an unchecked block",
+    "0x12": "Division or modulo division by zero",
+    "0x21":
+      "Tried to convert a value into an enum, but the value was too big or negative",
+    "0x22": "Incorrectly encoded storage byte array",
+    "0x31": ".pop() was called on an empty array",
+    "0x32": "Array accessed at an out-of-bounds or negative index",
+    "0x41":
+      "Too much memory was allocated, or an array was created that is too large",
+    "0x51": "Called a zero-initialized variable of internal function type",
   };
+  const code: HexNumber =
+    "0x" + BigInt(returnData.slice(PANIC_SELECTOR.length)).toString(16);
+  const reason = panicCodeToReason[code];
+  if (reason != null) {
+    return `execution reverted: panic code ${code} (${reason})`;
+  } else {
+    return `execution reverted: panic code ${code}`;
+  }
 }
 
-export function parseGwRunResultError(err: any): RpcError {
-  const gwErr = parseGwError(err);
-  const failedReason: any = {};
-  if (gwErr.statusCode != null) {
-    failedReason.status_code = "0x" + gwErr.statusCode.toString(16);
-    failedReason.status_type = evmcCodeTypeMapping[gwErr.statusCode.toString()];
-  }
-  if (gwErr.statusReason != null) {
-    failedReason.message = gwErr.statusReason;
-  }
-  let errorData: any = {};
-  if (Object.keys(failedReason).length !== 0) {
-    errorData = { failed_reason: failedReason };
-  }
-
-  let errorMessage = gwErr.message;
-  if (gwErr.statusReason != null && failedReason.status_type != null) {
-    // REVERT => revert
-    // compatible with https://github.com/EthWorks/Waffle/blob/ethereum-waffle%403.4.0/waffle-jest/src/matchers/toBeReverted.ts#L12
-    errorMessage = `${failedReason.status_type.toLowerCase()}: ${
-      gwErr.statusReason
-    }`;
-  }
-  errorData.message = errorMessage;
-  errorData.data = (gwErr.data as any).return_data;
-  return new RpcError(gwErr.code, errorMessage, errorData);
+/**
+ * Returns whether the error is a transaction execution error from Godwoken
+ */
+function isTransactionErrorInvalidExitCode(err: any): boolean {
+  const GODWOKEN_TRANSACTION_ERROR_INVALID_EXIT_CODE_PREFIX =
+    "invalid exit code ";
+  const message: string = err?.message;
+  return (
+    message != null &&
+    typeof message === "string" &&
+    message.startsWith(GODWOKEN_TRANSACTION_ERROR_INVALID_EXIT_CODE_PREFIX)
+  );
 }

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -74,6 +74,17 @@ export function handleGwError(gwJsonrpcError: any) {
  * @throws TransactionExecutionError
  */
 export function handleErrorTxReceipt(errorTxReceipt: ErrorTxReceipt) {
+  const GW_VM_MAX_CYCLE_EXIT_CODE = "0xff";
+
+  if (errorTxReceipt.exit_code === GW_VM_MAX_CYCLE_EXIT_CODE) {
+    throw new TransactionExecutionError("out of gas");
+  }
+
+  // fallback to general revert error
+  handleRevertError(errorTxReceipt);
+}
+
+function handleRevertError(errorTxReceipt: ErrorTxReceipt) {
   const returnData = errorTxReceipt.return_data;
   const message = parseReturnData(returnData);
   if (errorTxReceipt.return_data.length > 2) {

--- a/packages/api-server/src/methods/gw-error.ts
+++ b/packages/api-server/src/methods/gw-error.ts
@@ -27,16 +27,16 @@ export function isGwError(err: any): boolean {
 /**
  * Parse the given Godwoken error, translate into RpcError and then throw it
  *
- * @param gwJsonrpcError
+ * @param gwJsonRpcError
  *
  * @throws RpcError
  */
-export function handleGwError(gwJsonrpcError: any) {
-  if (!isGwError(gwJsonrpcError)) {
-    throw gwJsonrpcError;
+export function handleGwError(gwJsonRpcError: any) {
+  if (!isGwError(gwJsonRpcError)) {
+    throw gwJsonRpcError;
   }
 
-  const message: string = gwJsonrpcError?.message || gwJsonrpcError;
+  const message: string = gwJsonRpcError?.message || gwJsonRpcError;
   const err = JSON.parse(
     message.slice(GODWOKEN_SERVER_ERROR_MESSAGE_PREFIX.length)
   );
@@ -62,7 +62,7 @@ export function handleGwError(gwJsonrpcError: any) {
 
   throw new RpcError(
     err.code || INTERNAL_ERROR,
-    err.message || gwJsonrpcError.toString(),
+    err.message || gwJsonRpcError.toString(),
     err.data
   );
 }

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -519,7 +519,8 @@ export class Eth {
     } catch (error: any) {
       if (isGwError(error)) {
         handleGwError(error);
-      } else if (isRpcError(error)) {
+      }
+      if (isRpcError(error)) {
         throw error;
       }
       throw new Web3Error(error.message, error.data);
@@ -602,7 +603,8 @@ export class Eth {
     } catch (error: any) {
       if (isGwError(error)) {
         handleGwError(error);
-      } else if (isRpcError(error)) {
+      }
+      if (isRpcError(error)) {
         throw error;
       }
       throw new Web3Error(error.message);

--- a/packages/api-server/src/methods/modules/eth.ts
+++ b/packages/api-server/src/methods/modules/eth.ts
@@ -605,7 +605,7 @@ export class Eth {
       } else if (isRpcError(error)) {
         throw error;
       }
-      throw new Web3Error("UNPREDICTABLE_GAS_LIMIT: " + error.message);
+      throw new Web3Error(error.message);
     }
   }
 

--- a/packages/api-server/src/methods/modules/gw.ts
+++ b/packages/api-server/src/methods/modules/gw.ts
@@ -1,4 +1,4 @@
-import { parseGwRpcError, parseGwRunResultError } from "../gw-error";
+import { handleGwError } from "../gw-error";
 import {
   RPC,
   RunResult,
@@ -110,7 +110,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_ping(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -119,7 +119,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_tip_block_hash(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -135,7 +135,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_block_hash(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -149,7 +149,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_block(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -165,7 +165,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_block_by_number(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -182,7 +182,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_balance(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -199,7 +199,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_storage_at(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -224,7 +224,7 @@ export class Gw {
       }
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -241,7 +241,7 @@ export class Gw {
       const result = await this.rpc.gw_get_nonce(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -255,7 +255,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_script(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -271,7 +271,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_script_hash(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -287,7 +287,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_data(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -301,7 +301,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_transaction_receipt(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -324,7 +324,7 @@ export class Gw {
       }
       return txWithStatus;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -338,7 +338,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_execute_l2transaction(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -354,12 +354,8 @@ export class Gw {
       args[1] = formatHexNumber(args[1]);
 
       const executeCallResult = async () => {
-        let result: RunResult;
-        try {
-          result = await this.readonlyRpc.gw_execute_raw_l2transaction(...args);
-        } catch (error) {
-          throw parseGwRunResultError(error);
-        }
+        let result: RunResult =
+          await this.readonlyRpc.gw_execute_raw_l2transaction(...args);
         const stringifyResult = JSON.stringify(result);
         return stringifyResult;
       };
@@ -395,7 +391,7 @@ export class Gw {
         return JSON.parse(stringifyResult);
       }
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -556,7 +552,7 @@ export class Gw {
       const result = await this.rpc.gw_submit_l2transaction(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -570,7 +566,7 @@ export class Gw {
       const result = await this.rpc.gw_submit_withdrawal_request(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -586,7 +582,7 @@ export class Gw {
       );
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -617,7 +613,7 @@ export class Gw {
       }
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -631,7 +627,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_fee_config(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -645,7 +641,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_withdrawal(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -654,7 +650,7 @@ export class Gw {
       const result = await this.rpc.gw_get_last_submitted_info(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -663,7 +659,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_node_info(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 
@@ -672,7 +668,7 @@ export class Gw {
       const result = await this.rpc.gw_is_request_in_queue(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 

--- a/packages/api-server/src/methods/modules/gw.ts
+++ b/packages/api-server/src/methods/modules/gw.ts
@@ -677,7 +677,7 @@ export class Gw {
       const result = await this.readonlyRpc.gw_get_pending_tx_hashes(...args);
       return result;
     } catch (error) {
-      parseGwRpcError(error);
+      handleGwError(error);
     }
   }
 }

--- a/packages/api-server/tests/methods/gw.test.ts
+++ b/packages/api-server/tests/methods/gw.test.ts
@@ -4,10 +4,6 @@ import * as errcode from "../../src/methods/error-code";
 
 test("gw_get_storage_at", async (t) => {
   const res: JSONResponse = await client.request(t.title, []);
-  console.log(res);
-  console.log(res.error);
-  console.log(JSON.stringify(res));
-  console.log(JSON.stringify(res.error));
   t.truthy(res.error);
   t.is(res.error?.code, errcode.INVALID_PARAMS);
 });

--- a/packages/api-server/tests/methods/gw.test.ts
+++ b/packages/api-server/tests/methods/gw.test.ts
@@ -4,6 +4,10 @@ import * as errcode from "../../src/methods/error-code";
 
 test("gw_get_storage_at", async (t) => {
   const res: JSONResponse = await client.request(t.title, []);
+  console.log(res);
+  console.log(res.error);
+  console.log(JSON.stringify(res));
+  console.log(JSON.stringify(res.error));
   t.truthy(res.error);
   t.is(res.error?.code, errcode.INVALID_PARAMS);
 });

--- a/packages/godwoken/src/types.ts
+++ b/packages/godwoken/src/types.ts
@@ -24,6 +24,26 @@ export interface RunResult {
   logs: LogItem[];
 }
 
+/**
+ * @see {@link https://github.com/nervosnetwork/godwoken/blob/c4be58f30744aef83717e2a12d60fe4d50b165ab/crates/jsonrpc-types/src/godwoken.rs#L1310-L1317}
+ */
+export interface ErrorTxReceipt {
+  tx_hash: Hash;
+  block_number: HexU64;
+  return_data: HexString;
+  last_log?: LogItem[];
+  exit_code: HexU32;
+}
+
+export function isErrorTxReceipt(obj: any): obj is ErrorTxReceipt {
+  return (
+    "tx_hash" in obj &&
+    "block_number" in obj &&
+    "return_data" in obj &&
+    "exit_code" in obj
+  );
+}
+
 export interface RawL2Transaction {
   chain_id: HexU64;
   from_id: HexU32;


### PR DESCRIPTION
Main contribution:

- Fix https://github.com/nervosnetwork/godwoken-web3/issues/423

- Refactor handling of godwoken error.

  Because the `gw-error` module has been almost rewritten, I suggest reviewers read the file directly: https://github.com/nervosnetwork/godwoken-web3/blob/fc9ba1bced40ac38ecc2f5b4a7bd033952540a45/packages/api-server/src/methods/gw-error.ts
- Remove `error.data.failed_reason` and `error.data.message` from error JSONRPC response.

  See also: https://github.com/nervosnetwork/godwoken-web3/discussions/511

---

Others:

- Add test cases: https://github.com/nervosnetwork/godwoken-tests/pull/179/
- Remove handling of [`Err("can't find backend for script_hash")`](https://github.com/nervosnetwork/godwoken-web3/blob/98e4dc1e44a6b4530910b428bf66898516752ae7/packages/api-server/src/methods/gw-error.ts#L257-L263)
- Remove `UNPREDICTABLE_GAS_LIMIT` prefix from error response of `eth_estimateGas`