### PR TITLE
feat: use newrelic to collect errors

### DIFF
--- a/packages/api-server/newrelic.js
+++ b/packages/api-server/newrelic.js
@@ -33,6 +33,14 @@ exports.config = {
      */
     enabled: true
   },
+  error_collector: {
+    /**
+     * Enables/disables error collection.
+     *
+     * @env NEW_RELIC_ERROR_COLLECTOR_ENABLED
+     */
+    enabled: true,
+  },
   logging: {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing

--- a/packages/api-server/src/methods/validator.ts
+++ b/packages/api-server/src/methods/validator.ts
@@ -7,7 +7,7 @@ import {
 } from "../util";
 import { BlockParameter, BlockSpecifier } from "./types";
 import { logger } from "../base/logger";
-import { InvalidParamsError, RpcError } from "./error";
+import { InvalidParamsError, isRpcError, RpcError } from "./error";
 import { CKB_SUDT_ID, RPC_MAX_GAS_LIMIT } from "./constant";
 import { HexNumber, HexString } from "@ckb-lumos/base";
 import { envConfig } from "../base/env-config";
@@ -39,6 +39,9 @@ export function middleware(
 
       const err = validators[i](params, i);
       if (err) {
+        if (isRpcError(err)) {
+          throw err;
+        }
         throw new RpcError(err.code, err.message, err.data);
       }
     }
@@ -51,6 +54,9 @@ export function middleware(
       logger.error(
         `JSONRPC Server Error: [${method.name}] ${err} ${err.stack}`
       );
+      if (isRpcError(err)) {
+        throw err;
+      }
       throw new RpcError(err.code, err.message, err.data);
     }
   };


### PR DESCRIPTION
Our error responses are not automatically collected by NewRelic because we use Jayson instead of express' error handler.

This PR use `newrelic.noticeError` to collect errors into NewRelic.