### PR TITLE
feat: check batch request limit and RPC method rate limit

### DIFF
--- a/.github/workflows/godwoken-tests.yml
+++ b/.github/workflows/godwoken-tests.yml
@@ -17,3 +17,5 @@ jobs:
         MANUAL_BUILD_WEB3_INDEXER=true
         WEB3_GIT_URL=https://github.com/${{ github.repository }}
         WEB3_GIT_CHECKOUT=${{ github.ref }}
+        GODWOKEN_KICKER_REPO=godwokenrises/godwoken-kicker
+        GODWOKEN_KICKER_REF=1ba9ec08bf940e7222931ccc2940159dc877d1b4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: godwokenrises/godwoken-kicker
-        ref: 'develop'
+        ref: '1ba9ec08bf940e7222931ccc2940159dc877d1b4'
     - name: Kicker init
       run: ./kicker init
     - name: Kicker start

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ rate limit config
 ```bash
 $ cat > ./packages/api-server/rate-limit-config.json <<EOF
 {
+  "batch_limit": 1000,
   "expired_time_milsec": 60000,
   "methods": {
     "poly_executeRawL2Transaction": 30,

--- a/packages/api-server/src/cache/guard.ts
+++ b/packages/api-server/src/cache/guard.ts
@@ -11,8 +11,10 @@ const configPath = path.resolve(__dirname, "../../rate-limit-config.json");
 
 export const EXPIRED_TIME_MILSECS = 1 * 60 * 1000; // milsec, default 1 minutes
 export const MAX_REQUEST_COUNT = 30;
+export const BATCH_LIMIT = 100000; // 100_000 RPCs in single batch req
 
 export interface RateLimitConfig {
+  batch_limit: number;
   expired_time_milsec: number;
   methods: RpcMethodLimit;
 }
@@ -39,6 +41,7 @@ export class AccessGuard {
   public store: Store;
   public rpcMethods: RpcMethodLimit;
   public expiredTimeMilsecs: number;
+  public batchLimit: number;
 
   constructor(
     enableExpired = true,
@@ -51,6 +54,7 @@ export class AccessGuard {
     this.store = store || new Store(enableExpired, expiredTimeMilsecs);
     this.rpcMethods = config.methods;
     this.expiredTimeMilsecs = expiredTimeMilsecs || CACHE_EXPIRED_TIME_MILSECS;
+    this.batchLimit = config.batch_limit || BATCH_LIMIT;
   }
 
   async setMaxReqLimit(rpcMethod: string, maxReqCount: number) {

--- a/packages/api-server/src/cache/guard.ts
+++ b/packages/api-server/src/cache/guard.ts
@@ -79,11 +79,11 @@ export class AccessGuard {
     }
   }
 
-  async updateCount(rpcMethod: string, reqId: string, offset?: number) {
+  async updateCount(rpcMethod: string, reqId: string, offset: number = 1) {
     const isExist = await this.isExist(rpcMethod, reqId);
     if (isExist === true) {
       const id = getId(rpcMethod, reqId);
-      if (offset != null && offset > 1) {
+      if (offset > 1) {
         await this.store.incrBy(id, offset);
       } else {
         await this.store.incr(id);

--- a/packages/api-server/src/cache/store.ts
+++ b/packages/api-server/src/cache/store.ts
@@ -55,6 +55,17 @@ export class Store {
     return await this.client.incr(key);
   }
 
+  async incrBy(key: string, offset: number) {
+    const data = await this.client.get(key);
+    if (data == null) {
+      throw new Error("can not update before key exits");
+    }
+    if (isNaN(data as any)) {
+      throw new Error("can not update with NaN value");
+    }
+    return await this.client.incrBy(key, offset);
+  }
+
   async ttl(key: string) {
     return await this.client.ttl(key);
   }

--- a/packages/api-server/src/rate-limit.ts
+++ b/packages/api-server/src/rate-limit.ts
@@ -77,6 +77,21 @@ export function batchLimit(req: Request, res: Response) {
   return isBan;
 }
 
+export function wsBatchLimit(body: any): JSONRPCError[] | undefined {
+  if (isBatchLimit(body)) {
+    // if reach batch limit, we reject the whole req with error
+    const message = `Too Many Batch Requests ${body.length}, limit: ${accessGuard.batchLimit}.`;
+    const error: JSONRPCError = {
+      code: LIMIT_EXCEEDED,
+      message: message,
+    };
+    logger.debug(message);
+    return new Array(body.length).fill(error);
+  }
+
+  return undefined;
+}
+
 export async function rateLimit(
   req: Request,
   res: Response,
@@ -165,7 +180,7 @@ export function isBatchLimit(body: any) {
   if (Array.isArray(body)) {
     return body.length >= accessGuard.batchLimit;
   }
-  return true;
+  return false;
 }
 
 export function hasMethod(body: any, name: string) {

--- a/packages/api-server/src/ws/methods.ts
+++ b/packages/api-server/src/ws/methods.ts
@@ -12,7 +12,11 @@ import { Log, LogQueryOption, toApiLog } from "../db/types";
 import { filterLogsByAddress, filterLogsByTopics, Query } from "../db";
 import { Store } from "../cache/store";
 import { CACHE_EXPIRED_TIME_MILSECS } from "../cache/constant";
-import { wsApplyRateLimitByIp, wsBatchLimit } from "../rate-limit";
+import {
+  wsApplyBatchRateLimitByIp,
+  wsApplyRateLimitByIp,
+  wsBatchLimit,
+} from "../rate-limit";
 import { gwTxHashToEthTxHash } from "../cache/tx-hash";
 import { isInstantFinalityHackMode } from "../util";
 
@@ -84,16 +88,18 @@ export function wrapper(ws: any, req: any) {
       );
     }
 
+    // check batch rate limit
+    const batchErrs = await wsApplyBatchRateLimitByIp(req, objs);
+    if (batchErrs != null) {
+      return cb(
+        batchErrs.map((err) => {
+          return { err };
+        })
+      );
+    }
+
     const info = await Promise.all(
       objs.map(async (obj) => {
-        // check rate limit
-        const err = await wsApplyRateLimitByIp(req, obj.method);
-        if (err != null) {
-          return {
-            err,
-          };
-        }
-
         if (obj.method === "eth_subscribe") {
           const r = ethSubscribe(obj.params, callback);
           return r;


### PR DESCRIPTION
- add new config in `rate-limit-config.json`: `"batch_limit": <number, array max length of batch request>`
- fix the rate-limit count for single batch request, previously we only counted one for each batch request, this PR fix the count based on how many RPC method are inside the batch request